### PR TITLE
Fix React imports and add typings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { 
   Smartphone, 
   Shield, 

--- a/src/components/AdminPanel.tsx
+++ b/src/components/AdminPanel.tsx
@@ -10,18 +10,13 @@ import {
   Save, 
   X, 
   Search,
-  Filter,
   Download,
-  Upload,
   Eye,
   Shield,
   AlertTriangle,
   CheckCircle,
-  Clock,
   TrendingUp,
-  Database,
-  FileText,
-  HelpCircle
+  FileText
 } from 'lucide-react';
 import DataExporter from './DataExporter';
 import esperantoData, { Chapter, Section, Question, TheoryBlock } from '../data/esperantoData';

--- a/src/components/SectionsList.tsx
+++ b/src/components/SectionsList.tsx
@@ -6,15 +6,18 @@ import useEsperantoData from '../hooks/useEsperantoData';
 interface Section {
   id: number;
   title: string;
+  description: string;
   progress: number;
   duration: string;
   isCompleted: boolean;
+  isLocked?: boolean;
   theory?: {
     title: string;
     content: string;
     examples: string[];
     keyTerms: string[];
   };
+  questionsCount?: number;
 }
 
 interface SectionsListProps {

--- a/src/components/TelegramWebAppProvider.tsx
+++ b/src/components/TelegramWebAppProvider.tsx
@@ -42,7 +42,7 @@ export const TelegramWebAppProvider: React.FC<TelegramWebAppProviderProps> = ({ 
       if (telegramWebApp.isAvailable()) {
         setIsAvailable(true);
         setUser(telegramWebApp.getUser());
-        setIsDarkTheme(telegramWebApp.isDarkTheme());
+        setIsDarkTheme(Boolean(telegramWebApp.isDarkTheme()));
         setThemeParams(telegramWebApp.getThemeParams());
       }
     };

--- a/src/types/components.d.ts
+++ b/src/types/components.d.ts
@@ -1,0 +1,27 @@
+declare module "./components/SupabaseAuthProvider.jsx" {
+  import { ReactNode } from "react";
+  export interface AuthContextValue {
+    user: any;
+    profile: any;
+    loading: boolean;
+    error: string | null;
+    signIn: (...args: any[]) => Promise<void>;
+    signUp: (...args: any[]) => Promise<void>;
+    signOut: () => Promise<void>;
+    clearError: () => void;
+  }
+  export function SupabaseAuthProvider(props: { children: ReactNode }): JSX.Element;
+  export function useAuth(): AuthContextValue;
+  export default SupabaseAuthProvider;
+}
+
+declare module "./components/AuthModal.jsx" {
+  import { ReactNode } from "react";
+  export interface AuthModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    defaultMode?: "signin" | "signup";
+  }
+  export function AuthModal(props: AuthModalProps): JSX.Element;
+  export default AuthModal;
+}


### PR DESCRIPTION
## Summary
- clean unused imports in App and Admin panel
- extend Section interface for optional fields
- cast Telegram provider dark theme to boolean
- add module declarations for JSX components

## Testing
- `npm run lint` *(fails: cannot satisfy eslint rules)*

------
https://chatgpt.com/codex/tasks/task_e_6870e7c7fae083248ee433d122396ebe