### PR TITLE
Fix auth session check and safe student counts

### DIFF
--- a/src/components/ChaptersList.tsx
+++ b/src/components/ChaptersList.tsx
@@ -251,7 +251,12 @@ const ChaptersList: React.FC<ChaptersListProps> = ({ onChapterSelect, currentUse
                       </div>
                       <div className="flex items-center space-x-1">
                         <Users className="w-4 h-4" />
-                        <span>{chapter.studentsCount.toLocaleString()} студентов</span>
+                        <span>
+                          {chapter.studentsCount
+                            ? chapter.studentsCount.toLocaleString()
+                            : '0'}{' '}
+                          студентов
+                        </span>
                       </div>
                       <div className="flex items-center space-x-1">
                         <div className="flex">{renderStars(chapter.rating)}</div>

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -103,10 +103,13 @@ export async function signOut() {
  */
 export async function getCurrentUser() {
   try {
+    const { data: { session }, error: sessionError } = await supabase.auth.getSession()
+    if (sessionError) throw sessionError
+    if (!session) return null
+
     const { data: { user }, error } = await supabase.auth.getUser()
-    
     if (error) throw error
-    
+
     return user
   } catch (error) {
     console.error('❌ Ошибка получения пользователя:', error.message)


### PR DESCRIPTION
## Summary
- check session before fetching current user
- prevent crash in chapter list when studentsCount is missing

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*
- `npm run dev` *(started Vite dev server)*


------
https://chatgpt.com/codex/tasks/task_e_687133b974b88324bf149cff747ccf4f