### PR TITLE
Fix relative base path for Vite build

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,8 @@ import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  // Use relative paths so the app renders correctly when served from a subfolder
+  base: './',
   plugins: [react()],
   server: {
     host: true,


### PR DESCRIPTION
## Summary
- use relative `base` path in Vite config so the MiniApp renders correctly when served from subfolders

## Testing
- `npm run lint` *(fails: 58 errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687158676a988324a1badab255607480