### PR TITLE
Add AbortSignal.timeout polyfill

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,9 @@ import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
 import { SupabaseAuthProvider } from './components/SupabaseAuthProvider.jsx';
+import { patchAbortSignalTimeout } from './utils/patchAbortSignalTimeout';
+
+patchAbortSignalTimeout();
 
 // Hide loading screen when React app mounts
 function hideLoadingScreen() {

--- a/src/utils/patchAbortSignalTimeout.ts
+++ b/src/utils/patchAbortSignalTimeout.ts
@@ -1,0 +1,23 @@
+export function patchAbortSignalTimeout(): void {
+  if (typeof AbortSignal === 'undefined') {
+    return;
+  }
+
+  try {
+    // Test existing implementation in case it throws
+    if (typeof (AbortSignal as any).timeout === 'function') {
+      (AbortSignal as any).timeout(0);
+      return;
+    }
+  } catch {
+    // fall through to polyfill
+  }
+
+  // Polyfill AbortSignal.timeout for incompatible environments
+  (AbortSignal as any).timeout = function (ms: number): AbortSignal {
+    const controller = new AbortController();
+    const id = setTimeout(() => controller.abort(), ms);
+    controller.signal.addEventListener('abort', () => clearTimeout(id));
+    return controller.signal;
+  };
+}


### PR DESCRIPTION
## Summary
- polyfill `AbortSignal.timeout` for environments where it breaks
- ensure polyfill is applied during app startup

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68716894d0488324bba61cf4c2d6bacb