### PR TITLE
Fix responsive layout

### DIFF
--- a/src/components/ChaptersList.tsx
+++ b/src/components/ChaptersList.tsx
@@ -94,9 +94,9 @@ const ChaptersList: React.FC<ChaptersListProps> = ({ onChapterSelect, currentUse
   const recommendedChapter = getNextRecommendedChapter();
 
   return (
-    <div className="p-6 space-y-6 container-centered">
+    <div className="p-6 space-y-6 container-centered w-full">
       {/* Header */}
-      <div className="text-center mb-8">
+      <div className="text-center mb-8 w-full">
         <h1 className="text-3xl font-bold text-emerald-900 mb-2">Изучение эсперанто</h1>
         <p className="text-emerald-700 mb-4">Полный курс изучения международного языка эсперанто</p>
         
@@ -138,7 +138,7 @@ const ChaptersList: React.FC<ChaptersListProps> = ({ onChapterSelect, currentUse
 
       {/* Recommended Chapter */}
       {recommendedChapter && (
-        <div className="bg-gradient-to-r from-emerald-50 to-green-50 border-2 border-emerald-200 rounded-xl p-6 mb-6">
+        <div className="bg-gradient-to-r from-emerald-50 to-green-50 border-2 border-emerald-200 rounded-xl p-6 mb-6 w-full">
           <div className="flex items-center space-x-2 mb-3">
             <TrendingUp className="w-5 h-5 text-emerald-600" />
             <h3 className="text-lg font-semibold text-emerald-900">Рекомендуется изучить</h3>
@@ -160,7 +160,7 @@ const ChaptersList: React.FC<ChaptersListProps> = ({ onChapterSelect, currentUse
       )}
 
       {/* Filters */}
-      <div className="bg-white rounded-xl shadow-sm border border-emerald-200 p-4 mb-6">
+      <div className="bg-white rounded-xl shadow-sm border border-emerald-200 p-4 mb-6 w-full">
         <div className="flex flex-wrap gap-4 items-center">
           <div className="flex items-center space-x-2">
             <span className="text-sm font-medium text-emerald-800">Сложность:</span>
@@ -198,7 +198,7 @@ const ChaptersList: React.FC<ChaptersListProps> = ({ onChapterSelect, currentUse
       </div>
 
       {/* Chapters Grid */}
-      <div className="grid gap-6">
+      <div className="grid gap-6 w-full">
         {filteredChapters.map((chapter) => (
           <div
             key={chapter.id}
@@ -348,7 +348,7 @@ const ChaptersList: React.FC<ChaptersListProps> = ({ onChapterSelect, currentUse
       </div>
 
       {/* Learning Tips */}
-      <div className="bg-gradient-to-r from-emerald-50 to-green-50 border border-emerald-200 rounded-xl p-6">
+      <div className="bg-gradient-to-r from-emerald-50 to-green-50 border border-emerald-200 rounded-xl p-6 w-full">
         <div className="flex items-center space-x-2 mb-3">
           <Award className="w-5 h-5 text-emerald-600" />
           <h3 className="text-lg font-semibold text-emerald-900">

--- a/src/components/QuestionInterface.tsx
+++ b/src/components/QuestionInterface.tsx
@@ -451,7 +451,7 @@ const QuestionInterface: React.FC<QuestionInterfaceProps> = ({
 
         {/* Theory Content */}
         <div className="p-6">
-          <div className="max-w-4xl mx-auto container-centered">
+          <div className="max-w-4xl mx-auto container-centered w-full">
             <div className="bg-white rounded-xl shadow-sm border border-emerald-200 p-8 mb-6">
               <div className="flex items-center space-x-3 mb-6">
                 <div className="w-12 h-12 bg-emerald-100 rounded-lg flex items-center justify-center">

--- a/src/components/SectionsList.tsx
+++ b/src/components/SectionsList.tsx
@@ -40,8 +40,8 @@ const SectionsList: React.FC<SectionsListProps> = ({ chapterId, onSectionSelect,
 
 
   return (
-    <div className="p-6 space-y-4 container-centered">
-      <div className="flex items-center space-x-4 mb-6">
+    <div className="p-6 space-y-4 container-centered w-full">
+      <div className="flex items-center space-x-4 mb-6 w-full">
         <button
           onClick={onBackToChapters}
           className="p-2 hover:bg-emerald-100 rounded-lg transition-colors"
@@ -56,7 +56,7 @@ const SectionsList: React.FC<SectionsListProps> = ({ chapterId, onSectionSelect,
         </div>
       </div>
 
-      <div className="grid gap-4">
+      <div className="grid gap-4 w-full">
         {sections.map((section) => (
           <div
             key={section.id}
@@ -170,7 +170,7 @@ const SectionsList: React.FC<SectionsListProps> = ({ chapterId, onSectionSelect,
       </div>
 
       {/* Study Tips */}
-      <div className="bg-gradient-to-r from-blue-50 to-emerald-50 border border-blue-200 rounded-xl p-6 mt-8">
+      <div className="bg-gradient-to-r from-blue-50 to-emerald-50 border border-blue-200 rounded-xl p-6 mt-8 w-full">
         <div className="flex items-center space-x-2 mb-3">
           <Book className="w-5 h-5 text-blue-600" />
           <h3 className="text-lg font-semibold text-blue-900">Рекомендации по изучению</h3>

--- a/src/components/TestInterface.tsx
+++ b/src/components/TestInterface.tsx
@@ -265,7 +265,7 @@ const TestInterface: React.FC<TestInterfaceProps> = ({ onComplete, onBack }) => 
 
       {/* Question Content */}
       <div className="p-6">
-        <div className="max-w-4xl mx-auto container-centered">
+        <div className="max-w-4xl mx-auto container-centered w-full">
           <div className="bg-white rounded-xl shadow-sm border border-emerald-200 p-8">
             {/* Reading Passage */}
             {currentQuestionData.passage && (

--- a/src/components/TestIntro.tsx
+++ b/src/components/TestIntro.tsx
@@ -35,7 +35,7 @@ const TestIntro: React.FC<TestIntroProps> = ({ onStartTest }) => {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-emerald-50 to-green-50 p-6">
-      <div className="max-w-4xl mx-auto container-centered">
+      <div className="max-w-4xl mx-auto container-centered w-full">
         {/* Header */}
         <div className="text-center mb-8">
           <div className="w-20 h-20 bg-gradient-to-r from-emerald-600 to-green-600 rounded-full flex items-center justify-center mx-auto mb-6 shadow-lg">
@@ -51,7 +51,7 @@ const TestIntro: React.FC<TestIntroProps> = ({ onStartTest }) => {
 
         {/* Test Info */}
         <div className="bg-white rounded-xl shadow-lg border border-emerald-200 p-8 mb-8">
-          <div className="grid md:grid-cols-3 gap-6 mb-8">
+          <div className="grid md:grid-cols-3 gap-6 mb-8 w-full">
             <div className="text-center p-4 bg-emerald-50 rounded-lg border border-emerald-200">
               <div className="text-3xl font-bold text-emerald-600 mb-2">40</div>
               <div className="text-sm text-emerald-700 font-medium">Вопросов</div>
@@ -73,7 +73,7 @@ const TestIntro: React.FC<TestIntroProps> = ({ onStartTest }) => {
             Структура теста
           </h2>
           
-          <div className="grid md:grid-cols-2 gap-4 mb-8">
+          <div className="grid md:grid-cols-2 gap-4 mb-8 w-full">
             {testSections.map((section, index) => (
               <div key={index} className="flex items-center space-x-4 p-4 bg-emerald-50 rounded-lg border border-emerald-200">
                 <div className={`w-12 h-12 ${section.color} rounded-full flex items-center justify-center text-white shadow-lg`}>

--- a/src/components/TestResults.tsx
+++ b/src/components/TestResults.tsx
@@ -109,7 +109,7 @@ const TestResults: React.FC<TestResultsProps> = ({ results, onSaveResults, onRet
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-emerald-50 to-green-50 p-6">
-      <div className="max-w-4xl mx-auto container-centered">
+      <div className="max-w-4xl mx-auto container-centered w-full">
         {/* Header */}
         <div className="text-center mb-8">
           <div className="w-24 h-24 bg-gradient-to-r from-emerald-600 to-green-600 rounded-full flex items-center justify-center mx-auto mb-6 shadow-lg">
@@ -135,7 +135,7 @@ const TestResults: React.FC<TestResultsProps> = ({ results, onSaveResults, onRet
             </div>
           </div>
 
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8 w-full">
             <div className="text-center p-4 bg-emerald-50 rounded-lg border border-emerald-200">
               <div className="text-2xl font-bold text-emerald-900 mb-1">
                 {results.totalQuestions || 40}


### PR DESCRIPTION
## Summary
- ensure consistent width for containers and grids
- adjust chapter and section screens for mobile
- tweak intro and results layouts to be full width

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68721d9f67cc83249dac298cc2b2586e