### PR TITLE
Fix AbortSignal timeout polyfill

### DIFF
--- a/src/utils/patchAbortSignalTimeout.ts
+++ b/src/utils/patchAbortSignalTimeout.ts
@@ -3,14 +3,10 @@ export function patchAbortSignalTimeout(): void {
     return;
   }
 
-  try {
-    // Test existing implementation in case it throws
-    if (typeof (AbortSignal as any).timeout === 'function') {
-      (AbortSignal as any).timeout(0);
-      return;
-    }
-  } catch {
-    // fall through to polyfill
+  const anyAbortSignal = AbortSignal as any;
+  if (typeof anyAbortSignal.timeout === 'function') {
+    // Environment already supports AbortSignal.timeout
+    return;
   }
 
   // Polyfill AbortSignal.timeout for incompatible environments


### PR DESCRIPTION
## Summary
- fix AbortSignal.timeout polyfill check so Node timers work correctly

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6872297b26b08324a69c0fe86b6e8d49