### PR TITLE
Improve green theme styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
         margin: 0;
         padding: 0;
         font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-        background: var(--tg-theme-bg-color, #ffffff);
+        background: linear-gradient(135deg, #ecfdf5, #f0fdf4);
         color: var(--tg-theme-text-color, #000000);
         overflow-x: hidden;
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -289,19 +289,19 @@ function App() {
                 <button
                   key={item.id}
                   onClick={() => handleTabClick(item.id)}
-                  className={`flex flex-col items-center justify-center flex-1 py-2 px-2 transition-all duration-200 transform min-h-[60px] relative ${
-                    isActive 
-                      ? 'text-emerald-600 scale-105' 
-                      : 'text-gray-500 hover:text-emerald-500 active:scale-95'
+                  className={`group flex flex-col items-center justify-center flex-1 py-2 px-2 transition-all duration-200 transform min-h-[60px] relative ${
+                    isActive
+                      ? 'text-emerald-600 scale-105'
+                      : 'text-gray-500 hover:text-emerald-600 active:scale-95'
                   }`}
                 >
-                  <IconComponent 
+                  <IconComponent
                     className={`w-6 h-6 mb-1 transition-all duration-200 ${
-                      isActive ? 'text-emerald-600' : 'text-gray-500'
-                    }`} 
+                      isActive ? 'text-emerald-600' : 'text-gray-500 group-hover:text-emerald-600'
+                    }`}
                   />
                   <span className={`text-xs font-medium transition-all duration-200 text-center leading-tight ${
-                    isActive ? 'text-emerald-600' : 'text-gray-500'
+                    isActive ? 'text-emerald-600' : 'text-gray-500 group-hover:text-emerald-600'
                   }`}>
                     {item.label}
                   </span>

--- a/src/index.css
+++ b/src/index.css
@@ -50,7 +50,7 @@
   }
   .btn-green:hover {
     background-image: linear-gradient(to right, #047857, #15803d);
-    transform: scale(1.05);
+    transform: scale(1.1);
   }
   .progress-track {
     width: 100%;


### PR DESCRIPTION
## Summary
- make body use soft green gradient background
- enlarge green buttons to 110% on hover
- update navigation colors to change from gray to green when hovered

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68722f624c4c832481e6c1eaee379dab