### PR TITLE
Handle missing session in auth

### DIFF
--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -115,9 +115,17 @@ export async function signOut() {
 export async function getCurrentUser() {
   try {
     const { data: { user }, error } = await supabase.auth.getUser()
-    
-    if (error) throw error
-    
+
+    if (error) {
+      // When no active session is found Supabase returns an error
+      // with message "Auth session missing!". In this case we simply
+      // return null to indicate that the user is not authenticated.
+      if (error.message && error.message.includes('Auth session missing')) {
+        return null
+      }
+      throw error
+    }
+
     return user
   } catch (error) {
     console.error('❌ Ошибка получения пользователя:', error.message)


### PR DESCRIPTION
## Summary
- handle `Auth session missing!` error gracefully when getting current user

## Testing
- `npm run lint` *(fails: Cannot find package 'typescript-eslint')*

------
https://chatgpt.com/codex/tasks/task_e_68768762a0808324b4c5d1e9f589d50e