### PR TITLE
Fix checkWebApp timeout guard

### DIFF
--- a/src/components/TelegramWebAppProvider.tsx
+++ b/src/components/TelegramWebAppProvider.tsx
@@ -51,7 +51,11 @@ export const TelegramWebAppProvider: React.FC<TelegramWebAppProviderProps> = ({ 
     checkWebApp();
 
     // Check again after a short delay in case the script loads later
-    const timeout = setTimeout(checkWebApp, 100);
+    const timeout = setTimeout(() => {
+      if (typeof checkWebApp === 'function') {
+        checkWebApp();
+      }
+    }, 100);
 
     // Listen for back button
     const handleBackButton = () => {


### PR DESCRIPTION
## Summary
- avoid calling `checkWebApp` if the reference disappeared

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6877daae71d08324a6b164e151f3c09f