### PR TITLE
Add auth callback screen

### DIFF
--- a/src/components/AuthCallback.tsx
+++ b/src/components/AuthCallback.tsx
@@ -1,0 +1,29 @@
+import React, { useEffect } from 'react';
+import { supabase } from '../services/supabaseClient.js';
+
+const AuthCallback: React.FC = () => {
+  useEffect(() => {
+    const handleAuth = async () => {
+      try {
+        await supabase.auth.exchangeCodeForSession(window.location.href);
+      } catch (error) {
+        console.error('Auth callback error:', error);
+      } finally {
+        window.location.replace('/');
+      }
+    };
+
+    handleAuth();
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-emerald-50 to-green-50 flex items-center justify-center">
+      <div className="text-center">
+        <div className="w-12 h-12 border-4 border-emerald-600 border-t-transparent rounded-full animate-spin mx-auto mb-4"></div>
+        <p className="text-emerald-700">Подождите...</p>
+      </div>
+    </div>
+  );
+};
+
+export default AuthCallback;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
 import { SupabaseAuthProvider } from './components/SupabaseAuthProvider.jsx';
+import AuthCallback from './components/AuthCallback';
 
 // Hide loading screen when React app mounts
 function hideLoadingScreen() {
@@ -16,11 +17,12 @@ function hideLoadingScreen() {
 }
 
 const root = createRoot(document.getElementById('root')!);
+const isAuthCallback = window.location.pathname === '/auth/callback';
 
 root.render(
   <StrictMode>
     <SupabaseAuthProvider>
-      <App />
+      {isAuthCallback ? <AuthCallback /> : <App />}
     </SupabaseAuthProvider>
   </StrictMode>
 );


### PR DESCRIPTION
## Summary
- add `AuthCallback` spinner that exchanges the Supabase code and redirects home
- render `AuthCallback` when visiting `/auth/callback`

## Testing
- `npm run lint` *(fails: numerous lint errors)*
- `npm run build` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68795e46f918832486ccf0ff3fb6c6d1