### PR TITLE
Add basic OTP auth hook

### DIFF
--- a/src/components/SupabaseAuthProvider.jsx
+++ b/src/components/SupabaseAuthProvider.jsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext } from 'react'
-import { useSupabaseAuth } from '../hooks/useSupabaseAuth.js'
+import useAuthHook from '../hooks/useAuth.js'
 
 // Создаем контекст для аутентификации
 const SupabaseAuthContext = createContext(null)
@@ -10,7 +10,7 @@ const SupabaseAuthContext = createContext(null)
  * @param {React.ReactNode} props.children - Дочерние компоненты
  */
 export function SupabaseAuthProvider({ children }) {
-  const auth = useSupabaseAuth()
+  const auth = useAuthHook()
 
   return (
     <SupabaseAuthContext.Provider value={auth}>

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -1,0 +1,82 @@
+import { useEffect, useState } from 'react'
+import { supabase } from '../services/supabaseClient.js'
+
+/**
+ * Hook for Supabase email OTP authentication
+ */
+export default function useAuth() {
+  const [user, setUser] = useState(null)
+  const [emailSent, setEmailSent] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
+
+  // Subscribe to auth changes and restore session on mount
+  useEffect(() => {
+    let mounted = true
+
+    // Check current session
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (mounted) {
+        setUser(session?.user ?? null)
+      }
+    })
+
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (mounted) {
+        setUser(session?.user ?? null)
+      }
+    })
+
+    return () => {
+      mounted = false
+      subscription?.unsubscribe()
+    }
+  }, [])
+
+  // Sign in via magic link (OTP)
+  const signInWithEmail = async (email) => {
+    try {
+      setLoading(true)
+      setError(null)
+      setEmailSent(false)
+
+      const { error } = await supabase.auth.signInWithOtp({
+        email,
+        options: { emailRedirectTo: `${window.location.origin}/auth/callback` }
+      })
+
+      if (error) throw error
+
+      setEmailSent(true)
+    } catch (err) {
+      setError(err.message)
+      throw err
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const signOut = async () => {
+    try {
+      setLoading(true)
+      setError(null)
+      await supabase.auth.signOut()
+      setUser(null)
+    } catch (err) {
+      setError(err.message)
+      throw err
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return {
+    user,
+    emailSent,
+    loading,
+    error,
+    signInWithEmail,
+    signOut,
+    clearError: () => setError(null)
+  }
+}


### PR DESCRIPTION
## Summary
- implement a new `useAuth` hook for email-based OTP sign-in
- wire `SupabaseAuthProvider` to this new hook

## Testing
- `npm run lint` *(fails: cannot pass ESLint checks)*

------
https://chatgpt.com/codex/tasks/task_e_68795e41b4208324967ad57e6e96ae3b