### PR TITLE
Sanitize Telegram bot token in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install
 Создайте файл `.env` в корне проекта на основе `.env.example`:
 ```env
 # Telegram Bot
-TELEGRAM_BOT_TOKEN=8018730758:AAGRlA6ekrHPgsI5u28mPZJ3secL3cBXTMo
+TELEGRAM_BOT_TOKEN=your_telegram_bot_token
 BOT_USERNAME=EsperantoLetoBot
 WEBAPP_URL=https://tgminiapp.esperanto-leto.ru
 
@@ -251,7 +251,7 @@ https://tgminiapp.esperanto-leto.ru?mode=test
 
 ```env
 # Telegram Bot
-TELEGRAM_BOT_TOKEN=8018730758:AAGRlA6ekrHPgsI5u28mPZJ3secL3cBXTMo
+TELEGRAM_BOT_TOKEN=your_telegram_bot_token
 BOT_USERNAME=EsperantoLetoBot
 
 # WebApp URL (ОБЯЗАТЕЛЬНО HTTPS!)


### PR DESCRIPTION
## Summary
- replace hardcoded bot token with placeholder

## Testing
- `npm run lint` *(fails: SmartPhone variable unused and many type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68795e4a44608324963af2bfb058f9b7