### PR TITLE
Rename useSupabaseAuth hook

### DIFF
--- a/src/components/SupabaseAuthProvider.jsx
+++ b/src/components/SupabaseAuthProvider.jsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext } from 'react'
-import { useSupabaseAuth } from '../hooks/useSupabaseAuth.js'
+import useAuthState from '../hooks/useAuth.js'
 
 // Создаем контекст для аутентификации
 const SupabaseAuthContext = createContext(null)
@@ -10,7 +10,7 @@ const SupabaseAuthContext = createContext(null)
  * @param {React.ReactNode} props.children - Дочерние компоненты
  */
 export function SupabaseAuthProvider({ children }) {
-  const auth = useSupabaseAuth()
+  const auth = useAuthState()
 
   return (
     <SupabaseAuthContext.Provider value={auth}>

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -13,7 +13,7 @@ import { getUserStats } from '../services/progressService.js'
  * Хук для работы с аутентификацией Supabase
  * @returns {Object} Объект с состоянием аутентификации и методами
  */
-export function useSupabaseAuth() {
+export function useAuth() {
   const [user, setUser] = useState(null)
   const [profile, setProfile] = useState(null)
   const [stats, setStats] = useState(null)
@@ -180,4 +180,4 @@ export function useSupabaseAuth() {
   }
 }
 
-export default useSupabaseAuth
+export default useAuth


### PR DESCRIPTION
## Summary
- rename `useSupabaseAuth.js` to `useAuth.js`
- update SupabaseAuthProvider to use the renamed hook

## Testing
- `npm run lint` *(fails: @typescript-eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68795e4cee908324826322020e47e6d2