### PR TITLE
Fix redirect for Supabase magic link

### DIFF
--- a/src/components/MagicLinkLogin.tsx
+++ b/src/components/MagicLinkLogin.tsx
@@ -25,7 +25,15 @@ const MagicLinkLogin: React.FC<MagicLinkLoginProps> = ({ isOpen, onClose }) => {
 
     try {
       setLoading(true)
-      const { error: signInError } = await supabase.auth.signInWithOtp({ email })
+      const redirectTo =
+        window.location.hostname === 'localhost'
+          ? 'http://localhost:3000/auth/callback'
+          : 'https://tgminiapp.esperanto-leto.ru/auth/callback'
+
+      const { error: signInError } = await supabase.auth.signInWithOtp({
+        email,
+        options: { emailRedirectTo: redirectTo }
+      })
       if (signInError) throw signInError
       setSuccess(true)
     } catch (err) {

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -40,9 +40,14 @@ export default function useAuth() {
       setError(null)
       setEmailSent(false)
 
+      const redirectTo =
+        window.location.hostname === 'localhost'
+          ? 'http://localhost:3000/auth/callback'
+          : 'https://tgminiapp.esperanto-leto.ru/auth/callback'
+
       const { error } = await supabase.auth.signInWithOtp({
         email,
-        options: { emailRedirectTo: `${window.location.origin}/auth/callback` }
+        options: { emailRedirectTo: redirectTo }
       })
 
       if (error) throw error


### PR DESCRIPTION
## Summary
- add automatic redirect URL in MagicLinkLogin
- update signInWithOtp options in auth hook

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_687966ac2da88324b324cb20a24884c0