### PR TITLE
fix supabase email redirect

### DIFF
--- a/src/components/MagicLinkLogin.tsx
+++ b/src/components/MagicLinkLogin.tsx
@@ -25,14 +25,11 @@ const MagicLinkLogin: FC<MagicLinkLoginProps> = ({ isOpen, onClose }) => {
 
     try {
       setLoading(true)
-      const redirectTo =
-        window.location.hostname === 'localhost'
-          ? 'http://localhost:3000/auth/callback'
-          : 'https://tgminiapp.esperanto-leto.ru/auth/callback'
-
       const { error: signInError } = await supabase.auth.signInWithOtp({
         email,
-        options: { emailRedirectTo: redirectTo }
+        options: {
+          emailRedirectTo: 'https://tgminiapp.esperanto-leto.ru/auth/callback',
+        },
       })
       if (signInError) throw signInError
       setSuccess(true)

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -40,14 +40,11 @@ export default function useAuth() {
       setError(null)
       setEmailSent(false)
 
-      const redirectTo =
-        window.location.hostname === 'localhost'
-          ? 'http://localhost:3000/auth/callback'
-          : 'https://tgminiapp.esperanto-leto.ru/auth/callback'
-
       const { error } = await supabase.auth.signInWithOtp({
         email,
-        options: { emailRedirectTo: redirectTo }
+        options: {
+          emailRedirectTo: 'https://tgminiapp.esperanto-leto.ru/auth/callback'
+        }
       })
 
       if (error) throw error


### PR DESCRIPTION
## Summary
- update OTP auth flow to always redirect to the production callback URL

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' in eslint.config.js)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687972ee91b08324bdc9c2ec4a230688