### PR TITLE
Add email login via magic link

### DIFF
--- a/src/components/LoginByEmail.tsx
+++ b/src/components/LoginByEmail.tsx
@@ -1,0 +1,10 @@
+import { type FC } from 'react'
+import MagicLinkLogin, { type MagicLinkLoginProps } from './MagicLinkLogin'
+
+export interface LoginByEmailProps extends Omit<MagicLinkLoginProps, 'title' | 'buttonLabel'> {}
+
+const LoginByEmail: FC<LoginByEmailProps> = (props) => (
+  <MagicLinkLogin {...props} title="Вход по ссылке" buttonLabel="Войти" />
+)
+
+export default LoginByEmail

--- a/src/components/MagicLinkLogin.tsx
+++ b/src/components/MagicLinkLogin.tsx
@@ -2,12 +2,18 @@ import { useState, type FC } from 'react'
 import { X, Mail, Loader } from 'lucide-react'
 import { supabase } from '../services/supabaseClient.js'
 
-interface MagicLinkLoginProps {
+export interface MagicLinkLoginProps {
   isOpen: boolean
   onClose: () => void
+  title?: string
+  buttonLabel?: string
 }
-
-const MagicLinkLogin: FC<MagicLinkLoginProps> = ({ isOpen, onClose }) => {
+const MagicLinkLogin: FC<MagicLinkLoginProps> = ({
+  isOpen,
+  onClose,
+  title = 'Вход по ссылке',
+  buttonLabel = 'Отправить ссылку',
+}) => {
   const [email, setEmail] = useState('')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
@@ -47,7 +53,7 @@ const MagicLinkLogin: FC<MagicLinkLoginProps> = ({ isOpen, onClose }) => {
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
       <div className="bg-white rounded-2xl max-w-md w-full p-6">
         <div className="flex items-center justify-between mb-4">
-          <h2 className="text-xl font-bold text-emerald-900">Вход по ссылке</h2>
+          <h2 className="text-xl font-bold text-emerald-900">{title}</h2>
           <button onClick={onClose} className="p-2 hover:bg-gray-100 rounded-lg">
             <X className="w-5 h-5 text-gray-600" />
           </button>
@@ -75,7 +81,7 @@ const MagicLinkLogin: FC<MagicLinkLoginProps> = ({ isOpen, onClose }) => {
                 loading ? 'bg-gray-300 cursor-not-allowed' : 'bg-emerald-600 hover:bg-emerald-700'
               }`}
             >
-              {loading ? <Loader className="w-5 h-5 animate-spin mx-auto" /> : 'Send Magic Link'}
+              {loading ? <Loader className="w-5 h-5 animate-spin mx-auto" /> : buttonLabel}
             </button>
           </form>
         )}

--- a/src/components/MyAccount.tsx
+++ b/src/components/MyAccount.tsx
@@ -1,7 +1,8 @@
 import { useState, type FC } from 'react';
-import { User, Shield, LogOut, Settings, Trophy, Clock, BookOpen, CheckCircle } from 'lucide-react';
+import { User, LogIn, Shield, LogOut, Settings, Trophy, Clock, BookOpen, CheckCircle } from 'lucide-react';
 import { useAuth } from './SupabaseAuthProvider';
 import MagicLinkLogin from './MagicLinkLogin';
+import LoginByEmail from './LoginByEmail';
 
 interface MyAccountProps {
   onBackToHome: () => void;
@@ -10,6 +11,7 @@ interface MyAccountProps {
 const MyAccount: FC<MyAccountProps> = ({ onBackToHome }) => {
   const { user, profile, stats, loading, signOut, isAuthenticated } = useAuth();
   const [showMagicLinkModal, setShowMagicLinkModal] = useState(false);
+  const [showLoginModal, setShowLoginModal] = useState(false);
 
   const handleLogout = async () => {
     try {
@@ -65,13 +67,24 @@ const MyAccount: FC<MyAccountProps> = ({ onBackToHome }) => {
               </p>
 
               {/* Register Button */}
-              <div className="mb-6">
+              <div className="mb-4">
                 <button
                   onClick={() => setShowMagicLinkModal(true)}
                   className="w-full bg-gradient-to-r from-emerald-500 to-green-600 hover:from-emerald-600 hover:to-green-700 text-white font-semibold py-4 px-8 rounded-xl transition-all duration-200 transform hover:scale-105 shadow-lg flex items-center justify-center space-x-3"
                 >
                   <User className="w-6 h-6" />
                   <span>Зарегистрироваться</span>
+                </button>
+              </div>
+
+              {/* Login Button */}
+              <div className="mb-6">
+                <button
+                  onClick={() => setShowLoginModal(true)}
+                  className="w-full border border-emerald-500 text-emerald-600 font-semibold py-4 px-8 rounded-xl transition-all duration-200 transform hover:scale-105 hover:bg-emerald-50 shadow-lg flex items-center justify-center space-x-3"
+                >
+                  <LogIn className="w-6 h-6" />
+                  <span>Войти</span>
                 </button>
               </div>
 
@@ -122,6 +135,13 @@ const MyAccount: FC<MyAccountProps> = ({ onBackToHome }) => {
         <MagicLinkLogin
           isOpen={showMagicLinkModal}
           onClose={() => setShowMagicLinkModal(false)}
+          title="Регистрация"
+          buttonLabel="Зарегистрироваться"
+        />
+        {/* Login By Email */}
+        <LoginByEmail
+          isOpen={showLoginModal}
+          onClose={() => setShowLoginModal(false)}
         />
       </>
     );


### PR DESCRIPTION
## Summary
- extend MagicLinkLogin with customizable text
- add reusable `LoginByEmail` component
- expose login and registration modals in `MyAccount`

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6879f42a531c832498f9d978cec00d4c