### PR TITLE
Ensure session restored on app load

### DIFF
--- a/src/hooks/useSupabaseAuth.js
+++ b/src/hooks/useSupabaseAuth.js
@@ -1,12 +1,12 @@
 import { useState, useEffect } from 'react'
-import { 
-  getCurrentUser, 
-  getUserProfile, 
+import {
+  getUserProfile,
   onAuthStateChange,
   signIn as authSignIn,
   signUp as authSignUp,
   signOut as authSignOut
 } from '../services/authService.js'
+import { supabase } from '../services/supabaseClient.js'
 import { getUserStats } from '../services/progressService.js'
 
 /**
@@ -57,7 +57,12 @@ export function useSupabaseAuth() {
 
     const initAuth = async () => {
       try {
-        const currentUser = await getCurrentUser()
+        const { data: { session }, error } = await supabase.auth.getSession()
+
+        if (error) throw error
+
+        const currentUser = session?.user || null
+
         if (mounted) {
           await loadUserData(currentUser)
         }


### PR DESCRIPTION
## Summary
- load persisted Supabase session on initialization
- listen for auth state changes across tabs

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6879f9a5d8b8832491bd55c406ae9f8d