### PR TITLE
Implement magic link session sync

### DIFF
--- a/src/hooks/useSupabaseAuth.js
+++ b/src/hooks/useSupabaseAuth.js
@@ -92,9 +92,21 @@ export function useSupabaseAuth() {
       }
     })
 
+    const handleStorage = async (e) => {
+      if (e.key === 'supabase_session_updated') {
+        const { data: { session } } = await supabase.auth.getSession()
+        if (mounted) {
+          await loadUserData(session?.user || null)
+        }
+      }
+    }
+
+    window.addEventListener('storage', handleStorage)
+
     return () => {
       mounted = false
       subscription?.unsubscribe()
+      window.removeEventListener('storage', handleStorage)
     }
   }, [])
 

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -11,20 +11,23 @@ const AuthCallback = () => {
       const access_token = query.get('access_token')
       const refresh_token = query.get('refresh_token')
 
-      if (access_token && refresh_token) {
-        const { error } = await supabase.auth.setSession({
-          access_token,
-          refresh_token,
-        })
-        if (error) {
-          console.error(error)
-          setStatus('error')
-        } else {
-          setStatus('success')
-          if (window.Telegram?.WebApp?.close) {
-            window.Telegram.WebApp.close()
+        if (access_token && refresh_token) {
+          const { error } = await supabase.auth.setSession({
+            access_token,
+            refresh_token,
+          })
+          if (error) {
+            console.error(error)
+            setStatus('error')
+          } else {
+            setStatus('success')
+            localStorage.setItem('supabase_session_updated', Date.now().toString())
+            if (window.Telegram?.WebApp?.close) {
+              window.Telegram.WebApp.close()
+            } else {
+              window.close()
+            }
           }
-        }
       } else {
         setStatus('error')
       }


### PR DESCRIPTION
## Summary
- broadcast session updates with `localStorage` in AuthCallback page
- add cross-tab listener inside `useSupabaseAuth` hook

## Testing
- `npm run lint`
- `npm run build` *(fails: Module './components/QuestionInterface' has no exported member 'QuestionResults', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6879fceb3d0883249ff72d1451c90309