### PR TITLE
Improve Supabase data fetching for lessons

### DIFF
--- a/src/services/courseService.js
+++ b/src/services/courseService.js
@@ -24,21 +24,55 @@ export async function fetchSections(chapterId) {
 export async function fetchTheoryBlocks(sectionId) {
   const { data, error } = await supabase
     .from('theory_blocks')
-    .select('id, content')
+    .select('id, title, content, examples, key_terms')
     .eq('section_id', sectionId)
     .order('id')
 
-  if (error) throw error
-  return data || []
+  if (error) {
+    console.error('Ошибка загрузки теории:', error.message)
+    throw error
+  }
+
+  if (!data || data.length === 0) {
+    console.warn('Данные theory_blocks не найдены для section_id', sectionId)
+    return []
+  }
+
+  return data.map(block => ({
+    ...block,
+    examples:
+      typeof block.examples === 'string'
+        ? JSON.parse(block.examples)
+        : block.examples || [],
+    key_terms:
+      typeof block.key_terms === 'string'
+        ? JSON.parse(block.key_terms)
+        : block.key_terms || []
+  }))
 }
 
-export async function fetchQuestionsWithAnswers(sectionId) {
+export async function fetchQuestions(sectionId) {
   const { data, error } = await supabase
     .from('questions')
-    .select('id, text, hint, answers (id, text, is_correct)')
+    .select(
+      'id, type, question, options, correct_answer, explanation, hints, difficulty'
+    )
     .eq('section_id', sectionId)
     .order('id')
 
-  if (error) throw error
-  return data || []
+  if (error) {
+    console.error('Ошибка загрузки вопросов:', error.message)
+    throw error
+  }
+
+  if (!data || data.length === 0) {
+    console.warn('Данные questions не найдены для section_id', sectionId)
+    return []
+  }
+
+  return data.map(q => ({
+    ...q,
+    options: typeof q.options === 'string' ? JSON.parse(q.options) : q.options || [],
+    hints: typeof q.hints === 'string' ? JSON.parse(q.hints) : q.hints || []
+  }))
 }


### PR DESCRIPTION
## Summary
- fetch theory blocks & questions directly from Supabase tables
- parse JSON arrays for examples, key terms, options and hints
- show warning logs when data is missing
- render theory text with formatting and show "Данные не найдены" message when empty

## Testing
- `npm run lint`
- `npm run build` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_687a313389848324bc48080a8eb218f2