### PR TITLE
Add Supabase progress saving

### DIFF
--- a/src/hooks/useSaveProgress.ts
+++ b/src/hooks/useSaveProgress.ts
@@ -1,0 +1,66 @@
+import { useState, useEffect } from 'react'
+import { saveAnswer, getSectionProgress } from '../services/progressService.js'
+
+export interface ProgressRecord {
+  id: string
+  user_id: string
+  chapter_id: number
+  section_id: number
+  question_id: number
+  is_correct: boolean
+  answered_at: string
+  selected_answer: string
+  time_spent: number
+}
+
+export default function useSaveProgress(chapterId: number, sectionId: number) {
+  const [progress, setProgress] = useState<ProgressRecord[]>([])
+
+  useEffect(() => {
+    const load = async () => {
+      if (!chapterId || !sectionId) return
+      try {
+        const data = await getSectionProgress(chapterId, sectionId)
+        setProgress(data as ProgressRecord[])
+      } catch (err) {
+        console.error('Failed to load progress', err)
+      }
+    }
+    load()
+  }, [chapterId, sectionId])
+
+  const saveProgress = async (
+    questionId: number,
+    isCorrect: boolean,
+    selectedAnswer: string,
+    timeSpent = 0
+  ) => {
+    try {
+      const record = await saveAnswer(
+        chapterId,
+        sectionId,
+        questionId,
+        isCorrect,
+        selectedAnswer,
+        timeSpent
+      )
+      if (record) {
+        setProgress(prev => {
+          const idx = prev.findIndex(p => p.question_id === questionId)
+          if (idx !== -1) {
+            const updated = [...prev]
+            updated[idx] = record
+            return updated
+          }
+          return [...prev, record]
+        })
+      }
+      return record
+    } catch (err) {
+      console.error('Failed to save progress', err)
+      throw err
+    }
+  }
+
+  return { progress, saveProgress }
+}

--- a/src/services/progressService.js
+++ b/src/services/progressService.js
@@ -20,18 +20,21 @@ export async function saveAnswer(chapterId, sectionId, questionId, isCorrect, se
 
     const { data, error } = await supabase
       .from('user_progress')
-      .insert([
-        {
-          user_id: user.id,
-          chapter_id: chapterId,
-          section_id: sectionId,
-          question_id: questionId,
-          is_correct: isCorrect,
-          selected_answer: selectedAnswer,
-          time_spent: timeSpent,
-          answered_at: new Date().toISOString()
-        }
-      ])
+      .upsert(
+        [
+          {
+            user_id: user.id,
+            chapter_id: chapterId,
+            section_id: sectionId,
+            question_id: questionId,
+            is_correct: isCorrect,
+            selected_answer: selectedAnswer,
+            time_spent: timeSpent,
+            answered_at: new Date().toISOString()
+          }
+        ],
+        { onConflict: 'user_id,question_id' }
+      )
       .select()
       .single()
 


### PR DESCRIPTION
## Summary
- save question answers using `upsert`
- add `useSaveProgress` hook
- load section progress and show completion in SectionsList
- persist progress when answering questions

## Testing
- `npm run lint`
- `npm run build` *(fails: multiple TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_687a348113a48324a0e6ec842366635d