### PR TITLE
Handle unauthenticated progress saving

### DIFF
--- a/src/components/QuestionInterface.tsx
+++ b/src/components/QuestionInterface.tsx
@@ -34,7 +34,7 @@ const QuestionInterface: FC<QuestionInterfaceProps> = ({
   onComplete,
   onBackToSections
 }) => {
-  const { refreshStats } = useAuth()
+  const { refreshStats, isAuthenticated } = useAuth()
   const [currentQuestion, setCurrentQuestion] = useState(0);
   const [selectedAnswer, setSelectedAnswer] = useState('');
   const [showAnswer, setShowAnswer] = useState(false);
@@ -146,6 +146,11 @@ const QuestionInterface: FC<QuestionInterfaceProps> = ({
     }
 
     setAnswers(prev => [...prev, newAnswer])
+
+    if (!isAuthenticated) {
+      console.warn('Answer not saved: user is not authenticated')
+      return
+    }
 
     try {
       await saveAnswer(

--- a/src/services/progressService.js
+++ b/src/services/progressService.js
@@ -14,7 +14,10 @@ import { getCurrentUser } from './authService.js'
 export async function saveAnswer(chapterId, sectionId, questionId, isCorrect, selectedAnswer, timeSpent = 0) {
   try {
     const user = await getCurrentUser()
-    if (!user) throw new Error('Пользователь не авторизован')
+    if (!user) {
+      console.warn('User not authenticated, skipping save')
+      return null
+    }
 
     console.log('💾 Сохранение ответа:', { chapterId, sectionId, questionId, isCorrect })
 


### PR DESCRIPTION
## Summary
- guard saveAnswer when user is not logged in
- skip saving answers in UI if user isn't authenticated

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.app.json` *(fails: various TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_687a38525a748324a10b6dd7ceddbabd