### PR TITLE
Fix profile load and chapter progress

### DIFF
--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -74,18 +74,21 @@ export async function signUp(email, password, username) {
 export async function signIn(email, password) {
   try {
     console.log('🔐 Вход пользователя:', email)
-    
+
     const { data, error } = await supabase.auth.signInWithPassword({
       email,
       password
     })
-    
+
     if (error) throw error
-    
+
     console.log('✅ Вход выполнен успешно')
     return data
   } catch (error) {
     console.error('❌ Ошибка входа:', error.message)
+    if (error.code === 'invalid_credentials' || error.message === 'Invalid login credentials') {
+      throw new Error('Неверный email или пароль')
+    }
     throw new Error(`Ошибка входа: ${error.message}`)
   }
 }
@@ -144,11 +147,11 @@ export async function getUserProfile(userId) {
       .from('profiles')
       .select('*')
       .eq('id', userId)
-      .single()
-    
-    if (error) throw error
-    
-    return data
+      .maybeSingle()
+
+    if (error && error.code !== 'PGRST116') throw error
+
+    return data || null
   } catch (error) {
     console.error('❌ Ошибка получения профиля:', error.message)
     return null

--- a/src/services/progressService.js
+++ b/src/services/progressService.js
@@ -200,14 +200,13 @@ export async function getChapterProgressPercent(chapterId) {
 
     const { data: completed, error: progressError } = await supabase
       .from('user_progress')
-      .select('section_id', { count: 'exact' })
+      .select('section_id')
       .eq('user_id', user.id)
       .eq('chapter_id', chapterId)
-      .group('section_id')
 
     if (progressError) throw progressError
 
-    const completedCount = completed ? completed.length : 0
+    const completedCount = completed ? new Set(completed.map(p => p.section_id)).size : 0
 
     return Math.round((completedCount / totalSections) * 100)
   } catch (error) {


### PR DESCRIPTION
## Summary
- handle invalid credentials in `signIn`
- allow missing profile rows without throwing an error
- avoid unsupported `group()` call when counting chapter progress

## Testing
- `npm run lint`
- `npm run build` *(fails: Module '"./components/QuestionInterface"' has no exported member 'QuestionResults')*

------
https://chatgpt.com/codex/tasks/task_e_687a41ee21ac8324ace2f4fd761a0af2