### PR TITLE
Fix admin login by checking email

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,7 @@ import MyAccount from './components/MyAccount';
 import AdminPanel from './components/AdminPanel';
 import { useAuth } from './components/SupabaseAuthProvider';
 import { saveTestResults } from './services/progressService.js';
+import { isAdmin } from './utils/adminUtils.js';
 
 function App() {
   const [isVisible, setIsVisible] = useState(false);
@@ -168,7 +169,7 @@ function App() {
 
   // Функция для проверки прав администратора
   const hasAdminAccess = () => {
-    return profile?.username?.toLowerCase() === 'admin5050';
+    return isAdmin(profile?.username, profile?.email);
   };
 
   // Базовые элементы навигации

--- a/src/components/AdminPanel.tsx
+++ b/src/components/AdminPanel.tsx
@@ -20,6 +20,7 @@ import {
 } from 'lucide-react';
 import DataExporter from './DataExporter';
 import esperantoData, { Chapter, Section } from '../data/esperantoData';
+import { isAdmin } from '../utils/adminUtils.js';
 
 interface AdminUser {
   id: string;
@@ -54,6 +55,7 @@ interface SystemStats {
 interface AdminPanelProps {
   onClose: () => void;
   currentUser: string;
+  currentEmail: string;
 }
 
 type EditingItem =
@@ -62,7 +64,7 @@ type EditingItem =
 
 type AdminTab = 'content' | 'users' | 'analytics' | 'settings';
 
-const AdminPanel: FC<AdminPanelProps> = ({ onClose, currentUser }) => {
+const AdminPanel: FC<AdminPanelProps> = ({ onClose, currentUser, currentEmail }) => {
   const [activeTab, setActiveTab] = useState<AdminTab>('content');
   const [isAuthorized, setIsAuthorized] = useState(false);
   const [authError, setAuthError] = useState('');
@@ -90,16 +92,14 @@ const AdminPanel: FC<AdminPanelProps> = ({ onClose, currentUser }) => {
   });
 
   const checkAdminAccess = useCallback(() => {
-    // In a real application, this would check against a backend
-    const adminUsers = ['admin5050', 'admin', 'administrator'];
-    if (adminUsers.includes(currentUser.toLowerCase())) {
+    if (isAdmin(currentUser, currentEmail)) {
       setIsAuthorized(true);
-      console.log(`✅ Admin access granted for user: ${currentUser}`);
+      console.log(`✅ Admin access granted for user: ${currentUser || currentEmail}`);
     } else {
       setAuthError('У вас нет прав администратора для доступа к этой панели.');
-      console.log(`❌ Admin access denied for user: ${currentUser}`);
+      console.log(`❌ Admin access denied for user: ${currentUser || currentEmail}`);
     }
-  }, [currentUser]);
+  }, [currentUser, currentEmail]);
 
   const loadSystemData = useCallback(async () => {
     try {
@@ -216,7 +216,9 @@ const AdminPanel: FC<AdminPanelProps> = ({ onClose, currentUser }) => {
   const handleDeleteChapter = (chapterId: number) => {
     if (confirm('Вы уверены, что хотите удалить эту главу? Это действие нельзя отменить.')) {
       setChapters(prev => prev.filter(ch => ch.id !== chapterId));
-      console.log(`Chapter ${chapterId} deleted by admin ${currentUser}`);
+      console.log(
+        `Chapter ${chapterId} deleted by admin ${currentUser || currentEmail}`
+      );
     }
   };
 
@@ -300,7 +302,9 @@ const AdminPanel: FC<AdminPanelProps> = ({ onClose, currentUser }) => {
           ? { ...user, totalProgress: 0, chaptersCompleted: 0, testsCompleted: 0, currentChapter: 1, currentSection: 1 }
           : user
       ));
-      console.log(`User progress reset for ${userId} by admin ${currentUser}`);
+      console.log(
+        `User progress reset for ${userId} by admin ${currentUser || currentEmail}`
+      );
     }
   };
 
@@ -349,7 +353,7 @@ const AdminPanel: FC<AdminPanelProps> = ({ onClose, currentUser }) => {
           </div>
           <div className="flex items-center space-x-4">
             <div className="text-sm text-gray-600">
-              Администратор: <span className="font-semibold text-emerald-600">{currentUser}</span>
+              Администратор: <span className="font-semibold text-emerald-600">{currentUser || currentEmail}</span>
             </div>
             <button
               onClick={onClose}

--- a/src/components/ChaptersList.tsx
+++ b/src/components/ChaptersList.tsx
@@ -3,6 +3,7 @@ import { Play, Star, Trophy, BookOpen, Lock, CheckCircle, Clock, Users, Trending
 import CheckmarkIcon from './CheckmarkIcon';
 import { fetchChapters } from '../services/courseService.js'
 import { getChapterProgressPercent } from '../services/progressService.js'
+import { isAdmin } from '../utils/adminUtils.js'
 
 interface Chapter {
   id: number;
@@ -32,7 +33,7 @@ const ChaptersList: FC<ChaptersListProps> = ({ onChapterSelect, currentUser = ''
 
   // Функция для проверки прав администратора
   const hasAdminAccess = () => {
-    return currentUser?.toLowerCase() === 'admin5050';
+    return isAdmin(currentUser);
   };
 
   const [chapters, setChapters] = useState<Chapter[]>([])

--- a/src/components/MagicLinkLogin.tsx
+++ b/src/components/MagicLinkLogin.tsx
@@ -2,9 +2,9 @@ import { useState, type FC } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { X, Mail, Loader } from 'lucide-react'
 import { supabase } from '../services/supabaseClient.js'
+import { ADMIN_EMAIL } from '../utils/adminUtils.js'
 
 const EMAIL_REDIRECT = 'https://tgminiapp.esperanto-leto.ru/auth/callback'
-const ADMIN_EMAIL = 'admin5050@gmail.com'
 const ADMIN_PASSWORD = import.meta.env.VITE_ADMIN_PASSWORD || 'admin'
 
 export interface MagicLinkLoginProps {

--- a/src/components/MyAccount.tsx
+++ b/src/components/MyAccount.tsx
@@ -3,6 +3,7 @@ import { User, LogIn, Shield, LogOut, Settings, Trophy, Clock, BookOpen, CheckCi
 import { useAuth } from './SupabaseAuthProvider';
 import MagicLinkLogin from './MagicLinkLogin';
 import LoginByEmail from './LoginByEmail';
+import { isAdmin } from '../utils/adminUtils.js';
 
 interface MyAccountProps {
   onBackToHome: () => void;
@@ -33,7 +34,7 @@ const MyAccount: FC<MyAccountProps> = ({ onBackToHome }) => {
 
   // Функция для проверки прав администратора
   const hasAdminAccess = () => {
-    return profile?.username?.toLowerCase() === 'admin5050';
+    return isAdmin(profile?.username, user?.email);
   };
 
   if (loading) {

--- a/src/pages/AdminPanelPage.tsx
+++ b/src/pages/AdminPanelPage.tsx
@@ -6,7 +6,11 @@ const AdminPanelPage = () => {
   const navigate = useNavigate();
   const { profile } = useAuth();
   return (
-    <AdminPanel onClose={() => navigate('/')} currentUser={profile?.username || ''} />
+    <AdminPanel
+      onClose={() => navigate('/')}
+      currentUser={profile?.username || ''}
+      currentEmail={profile?.email || ''}
+    />
   );
 };
 

--- a/src/utils/adminUtils.ts
+++ b/src/utils/adminUtils.ts
@@ -1,0 +1,11 @@
+export const ADMIN_USERNAMES = ['admin5050', 'admin', 'administrator'];
+export const ADMIN_EMAILS = ['admin5050@gmail.com'];
+
+export function isAdmin(username?: string | null, email?: string | null): boolean {
+  const uname = username?.toLowerCase() || '';
+  const emailLower = email?.toLowerCase() || '';
+  return ADMIN_USERNAMES.includes(uname) || ADMIN_EMAILS.includes(emailLower);
+}
+
+export const ADMIN_EMAIL = ADMIN_EMAILS[0];
+export const ADMIN_USERNAME = ADMIN_USERNAMES[0];


### PR DESCRIPTION
## Summary
- share admin constants in new `adminUtils` helper
- reference admin email in magic link login
- pass user email to `AdminPanel` and validate with new util
- allow admin checks via email across app components

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687a44b71db8832491e3ba0be28cda90