### PR TITLE
Implement user profile editing

### DIFF
--- a/src/components/SupabaseAuthProvider.tsx
+++ b/src/components/SupabaseAuthProvider.tsx
@@ -13,6 +13,7 @@ export interface AuthContextValue {
   signIn: (email: string, password: string) => Promise<unknown>
   signUp: (email: string, password: string, username: string) => Promise<unknown>
   signOut: () => Promise<void>
+  updateProfile: (updates: Record<string, unknown>) => Promise<unknown>
   refreshStats: () => Promise<void>
   clearError: () => void
 }

--- a/src/hooks/useSupabaseAuth.js
+++ b/src/hooks/useSupabaseAuth.js
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import {
   getUserProfile,
+  updateUserProfile as authUpdateUserProfile,
   onAuthStateChange,
   signIn as authSignIn,
   signUp as authSignUp,
@@ -164,6 +165,23 @@ export function useSupabaseAuth() {
     }
   }
 
+  const updateProfile = async (updates) => {
+    if (!user) return null
+    try {
+      setLoading(true)
+      setError(null)
+
+      const updated = await authUpdateUserProfile(user.id, updates)
+      setProfile(updated)
+      return updated
+    } catch (err) {
+      setError(err.message)
+      throw err
+    } finally {
+      setLoading(false)
+    }
+  }
+
   // Обновление статистики
   const refreshStats = async () => {
     if (!user) return
@@ -198,6 +216,7 @@ export function useSupabaseAuth() {
     signIn,
     signUp,
     signOut,
+    updateProfile,
     refreshStats,
     
     // Утилиты


### PR DESCRIPTION
## Summary
- allow editing of username in MyAccount
- extend auth context with `updateProfile`
- support updating profile in auth hook

## Testing
- `npm run lint`
- `npm run build` *(fails: property type errors)*

------
https://chatgpt.com/codex/tasks/task_e_687a516375e08324810ab442081f67f0