### PR TITLE
Add auto profile creation on first login

### DIFF
--- a/src/hooks/useSupabaseAuth.js
+++ b/src/hooks/useSupabaseAuth.js
@@ -1,11 +1,12 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import {
   getUserProfile,
   updateUserProfile as authUpdateUserProfile,
   onAuthStateChange,
   signIn as authSignIn,
   signUp as authSignUp,
-  signOut as authSignOut
+  signOut as authSignOut,
+  ensureUserProfile
 } from '../services/authService.js'
 import { supabase } from '../services/supabaseClient.js'
 import { getUserStats, getUserAchievements } from '../services/progressService.js'
@@ -21,6 +22,7 @@ export function useSupabaseAuth() {
   const [achievements, setAchievements] = useState([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
+  const profileCheckedRef = useRef(false)
 
   // Загрузка данных пользователя
   const loadUserData = async (currentUser) => {
@@ -35,6 +37,11 @@ export function useSupabaseAuth() {
     try {
       setLoading(true)
       setError(null)
+
+      if (!profileCheckedRef.current) {
+        profileCheckedRef.current = true
+        await ensureUserProfile(currentUser)
+      }
 
       // Загружаем профиль, статистику и достижения параллельно
       const [userProfile, userStats, userAchievements] = await Promise.all([

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -187,6 +187,48 @@ export async function updateUserProfile(userId, updates) {
 }
 
 /**
+ * Ensure the user has a profile record in `profiles` table
+ * @param {Object} user - Supabase user object
+ */
+export async function ensureUserProfile(user) {
+  if (!user?.id) return
+  try {
+    const { data: existingProfile, error: fetchError } = await supabase
+      .from('profiles')
+      .select('*')
+      .eq('id', user.id)
+      .single()
+
+    if (fetchError && fetchError.code !== 'PGRST116') throw fetchError
+
+    if (!existingProfile) {
+      const { error: insertError } = await supabase.from('profiles').insert([
+        {
+          id: user.id,
+          username:
+            user.user_metadata?.username ||
+            user.email?.split('@')[0] ||
+            'Без имени',
+          email: user.email,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString()
+        }
+      ])
+
+      if (insertError) {
+        console.error('❌ Ошибка при создании профиля:', insertError)
+      } else {
+        console.log('✅ Профиль создан для нового пользователя.')
+      }
+    } else {
+      console.log('👤 Профиль уже существует.')
+    }
+  } catch (err) {
+    console.error('❌ Ошибка при проверке/создании профиля:', err)
+  }
+}
+
+/**
  * Подписка на изменения аутентификации
  * @param {Function} callback - Функция обратного вызова
  * @returns {Object} Объект подписки


### PR DESCRIPTION
## Summary
- add `ensureUserProfile` helper for Supabase
- call it from `useSupabaseAuth` when loading user data

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687a5521fe448324adf29c682e69c7ea