### PR TITLE
Improve layout centering

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,7 +113,7 @@
       }
     </style>
   </head>
-  <body>
+  <body class="scroll-smooth overflow-x-hidden">
     <!-- Universal Link Detection -->
     <div class="universal-link">
       <a href="https://t.me/EsperantoLetoBot/webapp" id="telegram-link">Open in Telegram</a>

--- a/src/components/ChaptersList.tsx
+++ b/src/components/ChaptersList.tsx
@@ -189,23 +189,25 @@ const ChaptersList: FC<ChaptersListProps> = ({ onChapterSelect, currentUser = ''
 
       {/* Recommended Chapter */}
       {recommendedChapter && (
-        <div className="bg-gradient-to-r from-emerald-50 to-green-50 border-2 border-emerald-200 rounded-xl p-6 mb-6">
-          <div className="flex items-center space-x-2 mb-3">
-            <TrendingUp className="w-5 h-5 text-emerald-600" />
-            <h3 className="text-lg font-semibold text-emerald-900">Рекомендуется изучить</h3>
-          </div>
-          <div className="flex items-center justify-between">
-            <div>
-              <h4 className="font-semibold text-emerald-900">{recommendedChapter.title}</h4>
-              <p className="text-sm text-emerald-700">{recommendedChapter.description}</p>
+        <div className="w-full max-w-md mx-auto px-4">
+          <div className="bg-white rounded-xl shadow-md p-4 mb-4">
+            <div className="flex items-center space-x-2 mb-3">
+              <TrendingUp className="w-5 h-5 text-emerald-600" />
+              <h3 className="text-lg font-semibold text-emerald-900">Рекомендуется изучить</h3>
             </div>
-            <button
-              onClick={() => onChapterSelect(recommendedChapter.id)}
-              className="bg-emerald-600 hover:bg-emerald-700 text-white font-semibold py-2 px-4 rounded-lg transition-colors duration-200 flex items-center space-x-2 shadow-lg"
-            >
-              <Play className="w-4 h-4" />
-              <span>Начать</span>
-            </button>
+            <div className="flex items-center justify-between">
+              <div>
+                <h4 className="font-semibold text-emerald-900">{recommendedChapter.title}</h4>
+                <p className="text-sm text-emerald-700">{recommendedChapter.description}</p>
+              </div>
+              <button
+                onClick={() => onChapterSelect(recommendedChapter.id)}
+                className="w-full h-12 px-4 py-2 rounded-lg flex items-center justify-center gap-2 bg-green-600 text-white font-semibold shadow"
+              >
+                <Play className="w-4 h-4" />
+                <span>Начать</span>
+              </button>
+            </div>
           </div>
         </div>
       )}
@@ -251,16 +253,16 @@ const ChaptersList: FC<ChaptersListProps> = ({ onChapterSelect, currentUser = ''
       {/* Chapters Grid */}
       <div className="grid gap-6">
         {filteredChapters.map((chapter) => (
-          <div
-            key={chapter.id}
-            className={`bg-white border rounded-xl shadow-sm hover:shadow-md transition-all duration-200 ${
-              chapter.isLocked && !hasAdminAccess()
-                ? 'border-gray-200 opacity-60' 
-                : 'border-emerald-200 hover:border-emerald-300'
-            }`}
-          >
-            {/* Chapter Content */}
-            <div className="p-6">
+          <div key={chapter.id} className="w-full max-w-md mx-auto px-4">
+            <div
+              className={`bg-white rounded-xl shadow-md p-4 mb-4 border transition-all duration-200 ${
+                chapter.isLocked && !hasAdminAccess()
+                  ? 'border-gray-200 opacity-60'
+                  : 'border-emerald-200 hover:border-emerald-300'
+              }`}
+            >
+              {/* Chapter Content */}
+              <div className="p-6">
               <div className="flex items-start justify-between mb-4">
                 <div className="flex items-start space-x-4 flex-1">
                   <div className={`w-12 h-12 rounded-full flex items-center justify-center text-white font-bold text-lg ${
@@ -365,12 +367,12 @@ const ChaptersList: FC<ChaptersListProps> = ({ onChapterSelect, currentUser = ''
               <button
                 onClick={() => onChapterSelect(chapter.id)}
                 disabled={chapter.isLocked && !hasAdminAccess()}
-                className={`w-full font-semibold py-3 px-4 rounded-lg transition-colors duration-200 flex items-center justify-center space-x-2 ${
+                className={`w-full h-12 px-4 py-2 rounded-lg flex items-center justify-center gap-2 font-semibold shadow transition-colors duration-200 ${
                   chapter.isLocked && !hasAdminAccess()
                     ? 'bg-gray-300 text-gray-500 cursor-not-allowed'
                     : hasAdminAccess() && chapter.isLocked
-                    ? 'bg-emerald-600 hover:bg-emerald-700 text-white shadow-lg border-2 border-emerald-400'
-                    : 'bg-emerald-600 hover:bg-emerald-700 text-white shadow-lg'
+                    ? 'bg-green-600 hover:bg-green-700 text-white border-2 border-emerald-400'
+                    : 'bg-green-600 hover:bg-green-700 text-white'
                 }`}
               >
                 {chapter.isLocked && !hasAdminAccess() ? (
@@ -392,6 +394,7 @@ const ChaptersList: FC<ChaptersListProps> = ({ onChapterSelect, currentUser = ''
               </button>
             </div>
           </div>
+        </div>
         ))}
       </div>
 

--- a/src/components/SectionsList.tsx
+++ b/src/components/SectionsList.tsx
@@ -93,7 +93,7 @@ const SectionsList: FC<SectionsListProps> = ({ chapterId, onSectionSelect, onBac
   }
 
   return (
-    <div className="p-6 space-y-4">
+    <div className="w-full max-w-md mx-auto px-4 space-y-4">
       <div className="flex items-center space-x-4 mb-6">
         <button
           onClick={onBackToChapters}
@@ -111,10 +111,8 @@ const SectionsList: FC<SectionsListProps> = ({ chapterId, onSectionSelect, onBac
 
       <div className="grid gap-4">
         {sections.map((section) => (
-          <div
-            key={section.id}
-            className="bg-gradient-to-r from-emerald-50 to-green-100 border border-emerald-200 rounded-xl shadow-sm hover:shadow-md transition-all duration-200"
-          >
+          <div key={section.id} className="w-full max-w-md mx-auto px-4">
+            <div className="bg-white rounded-xl shadow-md p-4 mb-4">
             {/* Theory Block */}
             {section.theory && (
               <div className="border-b border-emerald-200">
@@ -212,13 +210,14 @@ const SectionsList: FC<SectionsListProps> = ({ chapterId, onSectionSelect, onBac
 
               <button
                 onClick={() => onSectionSelect(section.id)}
-                className="w-full bg-emerald-600 hover:bg-emerald-700 text-white font-semibold py-3 px-4 rounded-lg transition-colors duration-200 flex items-center justify-center space-x-2 shadow-lg"
+                className="w-full h-12 px-4 py-2 rounded-lg flex items-center justify-center gap-2 bg-green-600 text-white font-semibold shadow"
               >
                 <Play className="w-5 h-5" />
                 <span>Начать изучение</span>
               </button>
             </div>
           </div>
+        </div>
         ))}
       </div>
 

--- a/src/components/TestIntro.tsx
+++ b/src/components/TestIntro.tsx
@@ -99,10 +99,10 @@ const TestIntro: FC<TestIntroProps> = ({ onStartTest }) => {
         </div>
 
         {/* Start Button */}
-        <div className="text-center">
+        <div className="text-center max-w-md mx-auto px-4">
           <button
             onClick={onStartTest}
-            className="bg-gradient-to-r from-emerald-600 to-green-600 hover:from-emerald-700 hover:to-green-700 text-white font-bold py-4 px-12 rounded-2xl text-xl transition-all duration-200 transform hover:scale-105 shadow-lg flex items-center space-x-3 mx-auto"
+            className="w-full h-12 px-4 py-2 rounded-lg flex items-center justify-center gap-2 bg-green-600 text-white font-semibold shadow"
           >
             <Play className="w-6 h-6" />
             <span>Начать тест</span>


### PR DESCRIPTION
## Summary
- center chapter and section cards with max width wrappers
- standardize Start buttons
- enable smooth scrolling on body

## Testing
- `npm run lint`
- `npm run build` *(fails: Property does not exist errors)*

------
https://chatgpt.com/codex/tasks/task_e_687a584587a0832491ccd1cdaf400d58