### PR TITLE
Fix card layout and button styles

### DIFF
--- a/src/components/ChaptersList.tsx
+++ b/src/components/ChaptersList.tsx
@@ -190,24 +190,22 @@ const ChaptersList: FC<ChaptersListProps> = ({ onChapterSelect, currentUser = ''
       {/* Recommended Chapter */}
       {recommendedChapter && (
         <div className="w-full max-w-md mx-auto px-4">
-          <div className="bg-white rounded-xl shadow-md p-4 mb-4">
-            <div className="flex items-center space-x-2 mb-3">
+          <div className="bg-white rounded-xl shadow-md p-4 mb-4 flex flex-col items-center text-center gap-4 box-border">
+            <div className="flex items-center space-x-2">
               <TrendingUp className="w-5 h-5 text-emerald-600" />
               <h3 className="text-lg font-semibold text-emerald-900">Рекомендуется изучить</h3>
             </div>
-            <div className="flex items-center justify-between">
-              <div>
-                <h4 className="font-semibold text-emerald-900">{recommendedChapter.title}</h4>
-                <p className="text-sm text-emerald-700">{recommendedChapter.description}</p>
-              </div>
-              <button
-                onClick={() => onChapterSelect(recommendedChapter.id)}
-                className="w-full h-12 px-4 py-2 rounded-xl flex items-center justify-center gap-2 bg-green-600 hover:bg-green-700 hover:scale-105 hover:-translate-y-0.5 hover:shadow-lg transition-all duration-300 ease-in-out text-white font-semibold shadow"
-              >
-                <Play className="w-4 h-4" />
-                <span>Начать</span>
-              </button>
+            <div>
+              <h4 className="font-semibold text-emerald-900">{recommendedChapter.title}</h4>
+              <p className="text-sm text-emerald-700">{recommendedChapter.description}</p>
             </div>
+            <button
+              onClick={() => onChapterSelect(recommendedChapter.id)}
+              className="w-full max-w-xs py-2 px-4 rounded-lg flex items-center justify-center gap-2 bg-green-600 text-white font-semibold shadow-sm hover:bg-green-700 hover:scale-105 hover:shadow-md transition-transform duration-200 active:scale-100 box-border"
+            >
+              <Play className="w-4 h-4" />
+              <span>Начать</span>
+            </button>
           </div>
         </div>
       )}
@@ -255,15 +253,15 @@ const ChaptersList: FC<ChaptersListProps> = ({ onChapterSelect, currentUser = ''
         {filteredChapters.map((chapter) => (
           <div key={chapter.id} className="w-full max-w-md mx-auto px-4">
             <div
-              className={`bg-white rounded-xl shadow-md p-4 mb-4 border transition-all duration-200 ${
+              className={`bg-white rounded-xl shadow-md p-4 mb-4 border transition-all duration-200 flex flex-col items-center text-center gap-4 box-border ${
                 chapter.isLocked && !hasAdminAccess()
                   ? 'border-gray-200 opacity-60'
                   : 'border-emerald-200 hover:border-emerald-300'
               }`}
             >
               {/* Chapter Content */}
-              <div className="p-6">
-              <div className="flex items-start justify-between mb-4">
+              <div className="p-6 flex flex-col items-center text-center gap-4 box-border">
+              <div className="flex items-start justify-between mb-4 w-full">
                 <div className="flex items-start space-x-4 flex-1">
                   <div className={`w-12 h-12 rounded-full flex items-center justify-center text-white font-bold text-lg ${
                     chapter.isLocked && !hasAdminAccess() ? 'bg-gray-400' : 'bg-emerald-600'
@@ -367,13 +365,11 @@ const ChaptersList: FC<ChaptersListProps> = ({ onChapterSelect, currentUser = ''
               <button
                 onClick={() => onChapterSelect(chapter.id)}
                 disabled={chapter.isLocked && !hasAdminAccess()}
-                className={`w-full h-12 px-4 py-2 rounded-xl flex items-center justify-center gap-2 font-semibold shadow transition-all duration-300 ease-in-out ${
+                className={`w-full max-w-xs py-2 px-4 rounded-lg flex items-center justify-center gap-2 font-semibold transition-transform duration-200 box-border ${
                   chapter.isLocked && !hasAdminAccess()
                     ? 'bg-gray-300 text-gray-500 cursor-not-allowed'
-                    : hasAdminAccess() && chapter.isLocked
-                    ? 'bg-green-600 text-white border-2 border-emerald-400 hover:bg-green-700 hover:scale-105 hover:-translate-y-0.5 hover:shadow-lg'
-                    : 'bg-green-600 text-white hover:bg-green-700 hover:scale-105 hover:-translate-y-0.5 hover:shadow-lg'
-                }`}
+                    : 'bg-green-600 text-white shadow-sm hover:bg-green-700 hover:scale-105 hover:shadow-md active:scale-100'
+                } ${hasAdminAccess() && chapter.isLocked ? 'border-2 border-emerald-400' : ''}`}
               >
                 {chapter.isLocked && !hasAdminAccess() ? (
                   <>

--- a/src/components/SectionsList.tsx
+++ b/src/components/SectionsList.tsx
@@ -210,7 +210,7 @@ const SectionsList: FC<SectionsListProps> = ({ chapterId, onSectionSelect, onBac
 
               <button
                 onClick={() => onSectionSelect(section.id)}
-                className="w-full h-12 px-4 py-2 rounded-xl flex items-center justify-center gap-2 bg-green-600 hover:bg-green-700 hover:scale-105 hover:-translate-y-0.5 hover:shadow-lg transition-all duration-300 ease-in-out text-white font-semibold shadow"
+                className="w-full max-w-xs py-2 px-4 rounded-lg flex items-center justify-center gap-2 bg-green-600 text-white font-semibold shadow-sm hover:bg-green-700 hover:scale-105 hover:shadow-md transition-transform duration-200 active:scale-100 box-border"
               >
                 <Play className="w-5 h-5" />
                 <span>Начать изучение</span>

--- a/src/components/TestIntro.tsx
+++ b/src/components/TestIntro.tsx
@@ -102,7 +102,7 @@ const TestIntro: FC<TestIntroProps> = ({ onStartTest }) => {
         <div className="text-center max-w-md mx-auto px-4">
           <button
             onClick={onStartTest}
-            className="w-full h-12 px-4 py-2 rounded-xl flex items-center justify-center gap-2 bg-green-600 hover:bg-green-700 hover:scale-105 hover:-translate-y-0.5 hover:shadow-lg transition-all duration-300 ease-in-out text-white font-semibold shadow"
+            className="w-full max-w-xs py-2 px-4 rounded-lg flex items-center justify-center gap-2 bg-green-600 text-white font-semibold shadow-sm hover:bg-green-700 hover:scale-105 hover:shadow-md transition-transform duration-200 active:scale-100 box-border"
           >
             <Play className="w-6 h-6" />
             <span>Начать тест</span>


### PR DESCRIPTION
## Summary
- center recommended chapter card
- make chapter cards flex containers
- use consistent Start button styling across course components

## Testing
- `npm run lint`
- `npm run build` *(fails: Module not found errors, typescript issues)*

------
https://chatgpt.com/codex/tasks/task_e_687a5b3ef194832490269e33129adb5b