### PR TITLE
Improve mobile layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -493,7 +493,7 @@ function App() {
       </header>
 
       {/* Hero Section */}
-      <section className="pt-16 pb-24">
+      <section className="pt-24 pb-24 md:pt-32 min-h-screen flex items-center">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="lg:grid lg:grid-cols-2 lg:gap-12 items-center">
             <div className={`transform transition-all duration-1000 ${isVisible ? 'translate-x-0 opacity-100' : '-translate-x-10 opacity-0'}`}>
@@ -559,7 +559,7 @@ function App() {
             <div className={`mt-16 lg:mt-0 transform transition-all duration-1000 delay-300 ${isVisible ? 'translate-x-0 opacity-100' : 'translate-x-10 opacity-0'}`}>
               <div className="relative">
                 {/* Phone mockup */}
-                <div className="mx-auto w-80 h-[640px] bg-emerald-900 rounded-[3rem] p-2 shadow-2xl">
+                <div className="mx-auto w-full max-w-xs aspect-[9/19] bg-emerald-900 rounded-[3rem] p-2 shadow-2xl">
                   <div className="w-full h-full bg-white rounded-[2.5rem] overflow-hidden relative">
                     {/* Status bar */}
                     <div className="bg-emerald-50 px-6 py-2 flex justify-between items-center text-sm font-semibold">

--- a/src/components/ChaptersList.tsx
+++ b/src/components/ChaptersList.tsx
@@ -145,7 +145,7 @@ const ChaptersList: FC<ChaptersListProps> = ({ onChapterSelect, currentUser = ''
   }
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="p-6 pt-20 space-y-6 mx-auto max-w-screen-sm">
       {/* Header */}
       <div className="text-center mb-8">
         <h1 className="text-3xl font-bold text-emerald-900 mb-2">Изучение эсперанто</h1>
@@ -189,8 +189,8 @@ const ChaptersList: FC<ChaptersListProps> = ({ onChapterSelect, currentUser = ''
 
       {/* Recommended Chapter */}
       {recommendedChapter && (
-        <div className="w-full max-w-md mx-auto px-4">
-          <div className="bg-white rounded-xl shadow-md p-4 mb-4 flex flex-col items-center text-center gap-4 box-border">
+        <div className="w-full max-w-sm mx-auto px-4">
+          <div className="bg-white rounded-xl shadow-md px-4 py-4 mb-4 flex flex-col items-center text-center gap-4 box-border">
             <div className="flex items-center space-x-2">
               <TrendingUp className="w-5 h-5 text-emerald-600" />
               <h3 className="text-lg font-semibold text-emerald-900">Рекомендуется изучить</h3>
@@ -251,16 +251,16 @@ const ChaptersList: FC<ChaptersListProps> = ({ onChapterSelect, currentUser = ''
       {/* Chapters Grid */}
       <div className="grid gap-6">
         {filteredChapters.map((chapter) => (
-          <div key={chapter.id} className="w-full max-w-md mx-auto px-4">
+          <div key={chapter.id} className="w-full max-w-sm mx-auto px-4">
             <div
-              className={`bg-white rounded-xl shadow-md p-4 mb-4 border transition-all duration-200 flex flex-col items-center text-center gap-4 box-border ${
+              className={`bg-white rounded-xl shadow-md px-4 py-4 mb-4 border transition-all duration-200 flex flex-col items-center text-center gap-4 box-border ${
                 chapter.isLocked && !hasAdminAccess()
                   ? 'border-gray-200 opacity-60'
                   : 'border-emerald-200 hover:border-emerald-300'
               }`}
             >
               {/* Chapter Content */}
-              <div className="p-6 flex flex-col items-center text-center gap-4 box-border">
+              <div className="p-4 flex flex-col items-center text-center gap-4 box-border">
               <div className="flex items-start justify-between mb-4 w-full">
                 <div className="flex items-start space-x-4 flex-1">
                   <div className={`w-12 h-12 rounded-full flex items-center justify-center text-white font-bold text-lg ${

--- a/src/components/SectionsList.tsx
+++ b/src/components/SectionsList.tsx
@@ -93,7 +93,7 @@ const SectionsList: FC<SectionsListProps> = ({ chapterId, onSectionSelect, onBac
   }
 
   return (
-    <div className="w-full max-w-md mx-auto px-4 space-y-4">
+    <div className="w-full max-w-screen-sm mx-auto px-4 space-y-4 pt-20">
       <div className="flex items-center space-x-4 mb-6">
         <button
           onClick={onBackToChapters}
@@ -111,8 +111,8 @@ const SectionsList: FC<SectionsListProps> = ({ chapterId, onSectionSelect, onBac
 
       <div className="grid gap-4">
         {sections.map((section) => (
-          <div key={section.id} className="w-full max-w-md mx-auto px-4">
-            <div className="bg-white rounded-xl shadow-md p-4 mb-4">
+          <div key={section.id} className="w-full max-w-sm mx-auto px-4">
+            <div className="bg-white rounded-xl shadow-md px-4 py-4 mb-4">
             {/* Theory Block */}
             {section.theory && (
               <div className="border-b border-emerald-200">


### PR DESCRIPTION
## Summary
- adjust hero section padding and phone mockup sizing
- center chapter/section lists for small screens
- limit lesson card width

## Testing
- `npm ci`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687a5e0e7fbc8324bf5702dacac65930