### PR TITLE
Fix Telegram login fallback

### DIFF
--- a/src/components/MyAccount.tsx
+++ b/src/components/MyAccount.tsx
@@ -15,6 +15,7 @@ import {
 } from 'lucide-react';
 import { v5 as uuidv5 } from 'uuid';
 import { useAuth } from './SupabaseAuthProvider';
+import { useTelegramWebApp } from './TelegramWebAppProvider';
 import { supabase } from '../services/supabaseClient.js';
 import { isAdmin } from '../utils/adminUtils.js';
 
@@ -38,6 +39,7 @@ const MyAccount: FC<MyAccountProps> = ({ onBackToHome }) => {
   const [newUsername, setNewUsername] = useState(profile?.username || '');
   const [loginLoading, setLoginLoading] = useState(false);
   const [tgUsername, setTgUsername] = useState<string | null>(null);
+  const { openTelegramLink } = useTelegramWebApp();
 
   useEffect(() => {
     setNewUsername(profile?.username || '');
@@ -77,7 +79,7 @@ const MyAccount: FC<MyAccountProps> = ({ onBackToHome }) => {
     const tg = window.Telegram?.WebApp;
     const userData = tg?.initDataUnsafe?.user;
     if (!userData) {
-      alert('Ошибка: Telegram не предоставил пользователя');
+      openTelegramLink('https://t.me/EsperantoLetoBot/webapp');
       return;
     }
 

--- a/src/components/TelegramWebAppProvider.tsx
+++ b/src/components/TelegramWebAppProvider.tsx
@@ -15,6 +15,7 @@ interface TelegramWebAppContextType {
   hideMainButton: () => void;
   showBackButton: () => void;
   hideBackButton: () => void;
+  openTelegramLink: (url: string) => void;
 }
 
 const TelegramWebAppContext = createContext<TelegramWebAppContextType | null>(null);
@@ -88,7 +89,8 @@ export const TelegramWebAppProvider: FC<TelegramWebAppProviderProps> = ({ childr
     setMainButton: telegramWebApp.setMainButton.bind(telegramWebApp),
     hideMainButton: telegramWebApp.hideMainButton.bind(telegramWebApp),
     showBackButton: telegramWebApp.showBackButton.bind(telegramWebApp),
-    hideBackButton: telegramWebApp.hideBackButton.bind(telegramWebApp)
+    hideBackButton: telegramWebApp.hideBackButton.bind(telegramWebApp),
+    openTelegramLink: telegramWebApp.openTelegramLink.bind(telegramWebApp)
   };
 
   return (

--- a/src/services/telegramWebApp.ts
+++ b/src/services/telegramWebApp.ts
@@ -73,6 +73,7 @@ interface TelegramWebApp {
   sendData(data: string): void;
   openLink(url: string): void;
   openTelegramLink(url: string): void;
+  openTelegramLink(url: string): void;
   showPopup(params: {
     title?: string;
     message: string;
@@ -264,6 +265,14 @@ class TelegramWebAppService {
 
   openLink(url: string) {
     this.webApp?.openLink(url);
+  }
+
+  openTelegramLink(url: string) {
+    if (this.webApp) {
+      this.webApp.openTelegramLink(url);
+    } else {
+      window.open(url, '_blank');
+    }
   }
 
   // Theme utilities


### PR DESCRIPTION
## Summary
- ensure Telegram WebApp service can open telegram links
- expose openTelegramLink in TelegramWebAppProvider
- fallback to opening miniapp via t.me from MyAccount

## Testing
- `npm run lint`
- `npm run build` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_687a745c89988324ade18b2b934b49e4