### PR TITLE
Fix TelegramWebApp provider usage

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import App from './App.tsx';
 import AdminPanelPage from './pages/AdminPanelPage';
 import './index.css';
 import { SupabaseAuthProvider } from './components/SupabaseAuthProvider';
+import { TelegramWebAppProvider } from './components/TelegramWebAppProvider';
 import AuthCallback from './pages/AuthCallback';
 
 // Hide loading screen when React app mounts
@@ -23,13 +24,15 @@ const root = createRoot(document.getElementById('root')!);
 root.render(
   <StrictMode>
     <BrowserRouter>
-      <SupabaseAuthProvider>
-        <Routes>
-          <Route path="/auth/callback" element={<AuthCallback />} />
-          <Route path="/admin-panel" element={<AdminPanelPage />} />
-          <Route path="/*" element={<App />} />
-        </Routes>
-      </SupabaseAuthProvider>
+      <TelegramWebAppProvider>
+        <SupabaseAuthProvider>
+          <Routes>
+            <Route path="/auth/callback" element={<AuthCallback />} />
+            <Route path="/admin-panel" element={<AdminPanelPage />} />
+            <Route path="/*" element={<App />} />
+          </Routes>
+        </SupabaseAuthProvider>
+      </TelegramWebAppProvider>
     </BrowserRouter>
   </StrictMode>
 );


### PR DESCRIPTION
## Summary
- wrap application in `TelegramWebAppProvider` so hooks can be used in components

## Testing
- `npm run lint`
- `npm run build` *(fails: Property 'progress' does not exist on type etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687a776056208324acd6355decb76f7c