### PR TITLE
Implement Telegram login RPC and update UI

### DIFF
--- a/src/components/MyAccount.tsx
+++ b/src/components/MyAccount.tsx
@@ -157,7 +157,7 @@ const MyAccount: FC<MyAccountProps> = ({ onBackToHome }) => {
                 <button
                   onClick={handleTelegramLogin}
                   disabled={loginLoading}
-                  className="w-full bg-gradient-to-r from-emerald-500 to-green-600 hover:from-emerald-600 hover:to-green-700 text-white font-semibold py-4 px-8 rounded-xl transition-all duration-200 transform hover:scale-105 shadow-lg flex items-center justify-center space-x-3"
+                  className="w-full mt-4 bg-green-600 text-white rounded-xl shadow-md hover:bg-green-700 transition"
                 >
                   <span>Начать через Telegram</span>
                 </button>

--- a/supabase/migrations/20250718210600_create_user_from_telegram.sql
+++ b/supabase/migrations/20250718210600_create_user_from_telegram.sql
@@ -1,0 +1,23 @@
+-- Create users table if it doesn't exist
+CREATE TABLE IF NOT EXISTS users (
+  id UUID PRIMARY KEY,
+  created_at TIMESTAMPTZ DEFAULT timezone('utc', now())
+);
+
+-- Function to create user from Telegram ID
+create or replace function create_user_from_telegram(
+  uid uuid,
+  username text,
+  email text
+) returns void as $$
+begin
+  insert into users(id, created_at)
+  values (uid, timezone('utc', now()))
+  on conflict do nothing;
+
+  insert into profiles(id, username, email, created_at, updated_at)
+  values (uid, username, email, timezone('utc', now()), timezone('utc', now()))
+  on conflict(id) do update
+    set updated_at = timezone('utc', now());
+end;
+$$ language plpgsql security definer;


### PR DESCRIPTION
## Summary
- add migration with `create_user_from_telegram` SQL function
- tweak Telegram login button style in `MyAccount`

## Testing
- `npm run lint`
- `npm run build` *(fails: module errors)*

------
https://chatgpt.com/codex/tasks/task_e_687a7d38d2a48324a43a6d2da7dd4f91