### PR TITLE
Fix missing uuid types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@eslint/js": "^8.57.0",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
+        "@types/uuid": "^10.0.0",
         "@vitejs/plugin-react": "^4.3.3",
         "autoprefixer": "^10.4.16",
         "eslint": "^8.57.0",
@@ -1514,6 +1515,13 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@eslint/js": "^8.57.0",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
+    "@types/uuid": "^10.0.0",
     "@vitejs/plugin-react": "^4.3.3",
     "autoprefixer": "^10.4.16",
     "eslint": "^8.57.0",


### PR DESCRIPTION
## Summary
- add `@types/uuid` to dev dependencies to resolve TypeScript errors

## Testing
- `npm run lint`
- `npm run build` *(fails: errors unrelated to uuid types)*

------
https://chatgpt.com/codex/tasks/task_e_687a801439e08324970217ecff6a88e5