### PR TITLE
Fix Telegram registration flow

### DIFF
--- a/src/services/telegramAuth.ts
+++ b/src/services/telegramAuth.ts
@@ -1,5 +1,6 @@
 import { supabase } from './supabaseClient.js';
 import { v5 as uuidv5 } from 'uuid';
+import { telegramWebApp } from './telegramWebApp';
 
 const TELEGRAM_NAMESPACE = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
 
@@ -12,7 +13,8 @@ export async function telegramLogin() {
   const tg = window.Telegram.WebApp;
   const user = tg.initDataUnsafe?.user;
   if (!user) {
-    console.error('Telegram user data not found');
+    console.warn('Telegram user data not found');
+    telegramWebApp.openTelegramLink('https://t.me/EsperantoLetoBot/webapp');
     return null;
   }
 


### PR DESCRIPTION
## Summary
- handle missing Telegram user info gracefully
- open bot link when user data is unavailable

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687a82cf86b08324abe208b0c44500f0