### PR TITLE
Implement automatic Telegram login

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -130,6 +130,12 @@ function App() {
     }
   }, []);
 
+  useEffect(() => {
+    if (window.location.pathname === '/account') {
+      setActiveTab('account');
+    }
+  }, []);
+
   const features = [
     {
       icon: <Shield className="w-8 h-8" />,


### PR DESCRIPTION
## Summary
- implement automatic Telegram login logic in `MyAccount`
- remove manual Telegram login button and show a spinner instead
- redirect to `/account` when a Telegram user is detected
- switch to account tab when URL path is `/account`

## Testing
- `npm run lint`
- `npm run build` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_687a8716d70883248e9931e7ae9babca