### PR TITLE
Auto redirect to account after Telegram login

### DIFF
--- a/src/components/TelegramLoginRedirect.tsx
+++ b/src/components/TelegramLoginRedirect.tsx
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { createOrGetProfile } from '../services/profileService';
+
+const TelegramLoginRedirect = () => {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const tgUser = window?.Telegram?.WebApp?.initDataUnsafe?.user;
+
+    if (tgUser) {
+      const upsertProfile = async () => {
+        await createOrGetProfile(tgUser);
+        navigate('/account');
+      };
+      upsertProfile();
+    }
+  }, []);
+
+  return null;
+};
+
+export default TelegramLoginRedirect;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,7 @@ import './index.css';
 import { SupabaseAuthProvider } from './components/SupabaseAuthProvider';
 import { TelegramWebAppProvider } from './components/TelegramWebAppProvider';
 import AuthCallback from './pages/AuthCallback';
+import TelegramLoginRedirect from './components/TelegramLoginRedirect';
 
 // Hide loading screen when React app mounts
 function hideLoadingScreen() {
@@ -26,6 +27,7 @@ root.render(
     <BrowserRouter>
       <TelegramWebAppProvider>
         <SupabaseAuthProvider>
+          <TelegramLoginRedirect />
           <Routes>
             <Route path="/auth/callback" element={<AuthCallback />} />
             <Route path="/admin-panel" element={<AdminPanelPage />} />

--- a/src/services/profileService.ts
+++ b/src/services/profileService.ts
@@ -1,0 +1,33 @@
+import { supabase } from './supabaseClient.js';
+
+export interface TelegramUser {
+  id: number;
+  username?: string;
+  first_name?: string;
+  last_name?: string;
+}
+
+/**
+ * Create profile for Telegram user if it does not exist and return the profile.
+ */
+export async function createOrGetProfile(user: TelegramUser) {
+  const { data, error } = await supabase
+    .from('profiles')
+    .upsert(
+      {
+        id: user.id.toString(),
+        username: user.username ?? `${user.first_name ?? ''}${user.last_name ?? ''}`,
+        email: `${user.username ?? user.id}@telegram`,
+        created_at: new Date().toISOString(),
+      },
+      { onConflict: 'id' }
+    )
+    .select()
+    .single();
+
+  if (error) {
+    console.error('createOrGetProfile error:', error);
+  }
+
+  return data;
+}


### PR DESCRIPTION
## Summary
- add profile service for Telegram-based profiles
- add TelegramLoginRedirect component for automatic redirect
- inject redirect component in main app

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687a92ec8d7483249b2c941240e9dfe3