### PR TITLE
Fix Telegram login loading loop

### DIFF
--- a/src/components/MyAccount.tsx
+++ b/src/components/MyAccount.tsx
@@ -46,7 +46,6 @@ const MyAccount: FC<MyAccountProps> = ({ onBackToHome }) => {
   const handleLogout = async () => {
     try {
       await signOut();
-      console.log('🚪 Пользователь вышел из системы');
     } catch (error) {
       console.error('❌ Ошибка выхода:', error);
     }
@@ -137,7 +136,7 @@ const MyAccount: FC<MyAccountProps> = ({ onBackToHome }) => {
 
   // Initial Login Screen
   if (!isAuthenticated) {
-    if (telegramUser) {
+    if (loginLoading) {
       return (
         <div className="min-h-screen bg-gradient-to-br from-emerald-50 to-green-50 flex items-center justify-center">
           <div className="text-center">

--- a/src/components/TelegramLoginRedirect.tsx
+++ b/src/components/TelegramLoginRedirect.tsx
@@ -1,23 +1,55 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { createOrGetProfile } from '../services/profileService';
+import { supabase } from '../services/supabaseClient.js';
 
 const TelegramLoginRedirect = () => {
   const navigate = useNavigate();
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const tgUser = window?.Telegram?.WebApp?.initDataUnsafe?.user;
-
-    if (tgUser) {
-      const upsertProfile = async () => {
-        await createOrGetProfile(tgUser);
-        navigate('/account');
-      };
-      upsertProfile();
+    const telegramUser = window?.Telegram?.WebApp?.initDataUnsafe?.user;
+    if (!telegramUser?.id) {
+      setLoading(false);
+      return;
     }
-  }, []);
 
-  return null;
+    const userId = telegramUser.id.toString();
+
+    const initProfile = async () => {
+      try {
+        const { data } = await supabase
+          .from('profiles')
+          .select('id')
+          .eq('id', userId)
+          .single();
+
+        if (!data) {
+          await supabase.from('profiles').insert({
+            id: userId,
+            username: telegramUser.username,
+            email: `${telegramUser.username}@telegram`,
+            created_at: new Date().toISOString(),
+          });
+        }
+
+        setLoading(false);
+        navigate('/account');
+      } catch (err) {
+        console.error('Ошибка входа:', err);
+        setLoading(false);
+      }
+    };
+
+    initProfile();
+  }, [navigate]);
+
+  if (!loading) return null;
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-white">
+      <div className="w-12 h-12 border-4 border-emerald-600 border-t-transparent rounded-full animate-spin" />
+    </div>
+  );
 };
 
 export default TelegramLoginRedirect;


### PR DESCRIPTION
## Summary
- handle Telegram login only once and show loader while creating profiles
- avoid permanent spinner on MyAccount when user is not authenticated
- remove leftover console log from logout handler

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687a9848b3288324ba0ea0f8b4e41eb8