### PR TITLE
Fix auth provider order

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -25,16 +25,18 @@ const root = createRoot(document.getElementById('root')!);
 root.render(
   <StrictMode>
     <BrowserRouter>
-      <TelegramWebAppProvider>
-        <SupabaseAuthProvider>
+      {/* SupabaseAuthProvider should wrap TelegramWebAppProvider so that */}
+      {/* the Telegram provider can access authentication context */}
+      <SupabaseAuthProvider>
+        <TelegramWebAppProvider>
           <TelegramLoginRedirect />
           <Routes>
             <Route path="/auth/callback" element={<AuthCallback />} />
             <Route path="/admin-panel" element={<AdminPanelPage />} />
             <Route path="/*" element={<App />} />
           </Routes>
-        </SupabaseAuthProvider>
-      </TelegramWebAppProvider>
+        </TelegramWebAppProvider>
+      </SupabaseAuthProvider>
     </BrowserRouter>
   </StrictMode>
 );


### PR DESCRIPTION
## Summary
- ensure TelegramWebAppProvider receives context by wrapping it inside SupabaseAuthProvider

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687a9f3cf5d883249be300a6fbfd9a4d