### PR TITLE
Fix Supabase onConflict usage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,8 +34,8 @@ import AIChat from './components/AIChat';
 import MyAccount from './components/MyAccount';
 import AdminPanel from './components/AdminPanel';
 import { useAuth } from './components/SupabaseAuthProvider';
-import { saveTestResults } from './services/progressService.js';
-import { updateChapterProgress } from './services/progressService';
+import { saveTestResults } from './services/progressService';
+import { updateChapterProgress } from './services/progressUpdater';
 import { supabase } from './services/supabaseClient.js';
 import { isAdmin } from './utils/adminUtils.js';
 
@@ -307,7 +307,7 @@ function App() {
             time_spent: timeSpent,
             completed: accuracy >= 70
           },
-          { onConflict: ['user_id', 'section_id'].join(',') }
+          { onConflict: ['user_id', 'section_id'] as any }
         );
         await updateChapterProgress(user_id, selectedChapter);
         await refreshStats();

--- a/src/components/ChaptersList.tsx
+++ b/src/components/ChaptersList.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, type FC } from 'react';
 import { Play, Star, Trophy, BookOpen, Lock, CheckCircle, Clock, Users, TrendingUp, Award, Shield } from 'lucide-react';
 import CheckmarkIcon from './CheckmarkIcon';
 import { fetchChapters } from '../services/courseService.js'
-import { getChapterProgressPercent } from '../services/progressService.js'
+import { getChapterProgressPercent } from '../services/progressService'
 import { isAdmin } from '../utils/adminUtils.js'
 
 interface Chapter {

--- a/src/components/QuestionInterface.tsx
+++ b/src/components/QuestionInterface.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, type FC } from 'react';
 import { HelpCircle, Eye, ArrowRight, X, Book } from 'lucide-react';
 import { fetchTheoryBlocks, fetchQuestions } from '../services/courseService.js'
-import { saveProgress } from '../services/progressService.js'
+import { saveProgress } from '../services/progressService'
 import { useAuth } from './SupabaseAuthProvider'
 
 

--- a/src/components/SectionsList.tsx
+++ b/src/components/SectionsList.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, type FC } from 'react';
 import { Play, Clock, Book, ChevronDown } from 'lucide-react';
 import CheckmarkIcon from './CheckmarkIcon';
 import { fetchSections } from '../services/courseService.js'
-import { getSectionProgressPercent } from '../services/progressService.js'
+import { getSectionProgressPercent } from '../services/progressService'
 
 interface Section {
   id: number;

--- a/src/hooks/useSupabaseAuth.js
+++ b/src/hooks/useSupabaseAuth.js
@@ -9,7 +9,7 @@ import {
   ensureUserProfile
 } from '../services/authService.js'
 import { supabase } from '../services/supabaseClient.js'
-import { getUserStats, getUserAchievements } from '../services/progressService.js'
+import { getUserStats, getUserAchievements } from '../services/progressService'
 
 /**
  * Хук для работы с аутентификацией Supabase

--- a/src/services/progressUpdater.ts
+++ b/src/services/progressUpdater.ts
@@ -1,4 +1,5 @@
 import { supabase } from './supabaseClient.js'
+export * from './progressService.js'
 
 export async function updateChapterProgress(user_id: string, chapter_id: number): Promise<void> {
   const { data: allSections } = await supabase
@@ -48,7 +49,7 @@ export async function updateChapterProgress(user_id: string, chapter_id: number)
           average_accuracy: avgAccuracy,
           total_time: totalTime
         },
-        { onConflict: ['user_id', 'chapter_id'].join(',') }
+        { onConflict: ['user_id', 'chapter_id'] as any }
       )
   }
 }


### PR DESCRIPTION
## Summary
- pass composite key as array in Supabase upserts
- rename TS helper to `progressUpdater.ts`
- update imports to use new helper and unify progressService path

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687ab9c2b3e08324af3323ab413d833a