### PR TITLE
Enable npm test via node's built‑in runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "bot:dev": "node --watch src/bot/index.js",
     "start": "concurrently \"npm run dev\" \"npm run bot:dev\" --names \"WebApp,TelegramBot\" --prefix-colors \"cyan,yellow\"",
     "start:prod": "concurrently \"npm run preview\" \"npm run bot\" --names \"WebApp,TelegramBot\" --prefix-colors \"green,blue\"",
-    "diagnostics": "node src/bot/diagnostics.js"
+    "diagnostics": "node src/bot/diagnostics.js",
+    "test": "node --test"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.50.3",

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -1,0 +1,6 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+test('sanity check', () => {
+  assert.equal(true, true)
+})


### PR DESCRIPTION
## Summary
- add minimal Node test
- wire up `npm test` to run `node --test`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687acf47a7688324b3dbf260ce90b2e4