### PR TITLE
Add toast for chapter completion

### DIFF
--- a/src/components/ChaptersList.tsx
+++ b/src/components/ChaptersList.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, type FC } from 'react';
 import { Play, Star, Trophy, BookOpen, Lock, CheckCircle, Clock, Users, TrendingUp, Award, Shield, Check } from 'lucide-react';
 import CheckmarkIcon from './CheckmarkIcon';
+import Toast from './Toast';
 import { fetchChapters } from '../services/courseService.js'
 import { getChapterProgressPercent } from '../services/progressService'
 import { isAdmin } from '../utils/adminUtils.js'
@@ -41,6 +42,7 @@ const ChaptersList: FC<ChaptersListProps> = ({ onChapterSelect, currentUser = ''
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [chapterProgress, setChapterProgress] = useState<Record<number, { completed: boolean; average_accuracy: number }>>({})
+  const [toastMessage, setToastMessage] = useState<string | null>(null)
 
   useEffect(() => {
     const load = async () => {
@@ -102,6 +104,21 @@ const ChaptersList: FC<ChaptersListProps> = ({ onChapterSelect, currentUser = ''
 
     loadProgress()
   }, [])
+
+  // Показываем уведомление о завершении главы
+  useEffect(() => {
+    if (!chapters.length) return
+    for (const ch of chapters) {
+      if (chapterProgress[ch.id]?.completed) {
+        const key = `chapter_reward_${ch.id}`
+        if (!localStorage.getItem(key)) {
+          setToastMessage(`Поздравляем! Вы завершили главу ${ch.title}`)
+          localStorage.setItem(key, 'true')
+          break
+        }
+      }
+    }
+  }, [chapterProgress, chapters])
 
 
   const getBadgeIcon = (badge: string) => {
@@ -499,6 +516,9 @@ const ChaptersList: FC<ChaptersListProps> = ({ onChapterSelect, currentUser = ''
           )}
         </div>
       </div>
+      {toastMessage && (
+        <Toast message={toastMessage} onClose={() => setToastMessage(null)} />
+      )}
     </div>
   );
 };

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,27 @@
+import { FC, useEffect } from 'react';
+import { X, Trophy } from 'lucide-react';
+
+interface ToastProps {
+  message: string;
+  onClose: () => void;
+  duration?: number;
+}
+
+const Toast: FC<ToastProps> = ({ message, onClose, duration = 4000 }) => {
+  useEffect(() => {
+    const timer = setTimeout(onClose, duration);
+    return () => clearTimeout(timer);
+  }, [onClose, duration]);
+
+  return (
+    <div className="fixed bottom-24 left-1/2 -translate-x-1/2 z-50 bg-green-600 text-white px-4 py-3 rounded-lg shadow-lg flex items-center space-x-2">
+      <Trophy className="w-5 h-5" />
+      <span className="font-medium">{message}</span>
+      <button onClick={onClose} className="ml-2">
+        <X className="w-4 h-4" />
+      </button>
+    </div>
+  );
+};
+
+export default Toast;


### PR DESCRIPTION
## Summary
- add simple Toast component
- show notification when a chapter reaches 100% progress

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: TS2769 in App.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_687ae3dddce08324a1ebc90f9ad4e5fe