### PR TITLE
Add visual log entries for progress handlers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -279,6 +279,7 @@ function App() {
   };
 
   const handleQuestionComplete = async (results: QuestionResults) => {
+    setDebugLogs((logs) => [...logs, '📥 handleQuestionComplete вызван']);
     setSectionResults(results);
     if (selectedChapter && selectedSection) {
       try {
@@ -340,6 +341,7 @@ function App() {
   };
 
   const handleTestComplete = async (results: FullTestResults) => {
+    setDebugLogs((logs) => [...logs, '📥 handleTestComplete вызван']);
     setTestResults(results);
 
     const correct = results.answers?.filter(a => a.isCorrect).length || 0;


### PR DESCRIPTION
## Summary
- log when handleQuestionComplete and handleTestComplete are triggered

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687aeee8d4e8832483d664b30709bca7