### PR TITLE
Add detailed debug logs in question completion

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -279,11 +279,19 @@ function App() {
   };
 
   const handleQuestionComplete = async (results: QuestionResults) => {
+    setDebugLogs((logs) => [
+      ...logs,
+      `✅ handleQuestionComplete: ${JSON.stringify(results)}`
+    ]);
     setDebugLogs((logs) => [...logs, '📥 handleQuestionComplete вызван']);
     setSectionResults(results);
     if (selectedChapter && selectedSection) {
       try {
         const timeSpent = sectionStartTime ? Math.round((Date.now() - sectionStartTime) / 1000) : 0;
+        setDebugLogs((logs) => [
+          ...logs,
+          `📤 saveProgressToSupabase: chapter=${selectedChapter}, section=${selectedSection}`
+        ]);
         await saveProgressToSupabase(
           selectedChapter,
           selectedSection,


### PR DESCRIPTION
## Summary
- add a detailed log of question results when `handleQuestionComplete` runs
- log chapter and section before saving progress

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b5e852b8c832499b1a4860e1bb653