### PR TITLE
Add mount debug log and reposition VisualLog

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -184,6 +184,10 @@ function App() {
     }
   }, []);
 
+  useEffect(() => {
+    setDebugLogs(['🧪 Тестовое сообщение для лога']);
+  }, []);
+
   const location = useLocation();
 
   useEffect(() => {
@@ -996,8 +1000,8 @@ function App() {
         </div>
       </footer>
 
-      <VisualLog logs={debugLogs} />
       <NavigationBar />
+      <VisualLog logs={debugLogs} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- display VisualLog after the navigation bar
- show a temporary debug message when the app mounts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b6100ffe083249550bef8c197f424