### PR TITLE
Fix progress save with UUID

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -96,8 +96,30 @@ function App() {
     timeSpent: number
   ) => {
     const { data: { user } } = await supabase.auth.getUser();
-    const userId = user?.id || localStorage.getItem('user_id') || (profile as any)?.id;
+    let userId = user?.id || localStorage.getItem('user_id') || (profile as any)?.id;
     setDebugLogs((logs) => [...logs, '👤 Полученный userId: ' + userId]);
+
+    // Convert Telegram numeric ID to UUID stored in profiles table
+    if (userId && /^\d+$/.test(userId)) {
+      setDebugLogs((logs) => [...logs, `🔎 Ищем UUID в profiles по telegramId ${userId}`]);
+      const { data: profileData, error: profileError } = await supabase
+        .from('profiles')
+        .select('id')
+        .eq('user_id', userId)
+        .maybeSingle();
+
+      if (profileError) {
+        setDebugLogs((logs) => [...logs, `❌ Ошибка поиска профиля: ${profileError.message}`]);
+      }
+
+      if (profileData?.id) {
+        userId = profileData.id as string;
+        setDebugLogs((logs) => [...logs, `📛 Найден UUID: ${userId}`]);
+      } else {
+        setDebugLogs((logs) => [...logs, '❌ UUID для Telegram ID не найден']);
+      }
+    }
+
     if (!userId) {
       setDebugLogs((logs) => [...logs, '❌ Нет user_id, прогресс не будет сохранён']);
       return;


### PR DESCRIPTION
## Summary
- map telegram numeric ID to UUID before saving progress
- log debug info when looking up profiles by telegram ID

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b75276b588324b528d1242139e939