### PR TITLE
Fix user lookup by Telegram ID

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -105,7 +105,7 @@ function App() {
       const { data: profileData, error: profileError } = await supabase
         .from('profiles')
         .select('id')
-        .eq('user_id', userId)
+        .eq('telegram_id', userId)
         .maybeSingle();
 
       if (profileError) {


### PR DESCRIPTION
## Summary
- search profiles table by `telegram_id` when converting Telegram numeric IDs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b84c22d5483249261b40e67a383c0