### PR TITLE
Handle Telegram numeric ID in progress saving

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -100,12 +100,16 @@ function App() {
     setDebugLogs((logs) => [...logs, '👤 Полученный userId: ' + userId]);
 
     // Convert Telegram numeric ID to UUID stored in profiles table
-    if (userId && /^\d+$/.test(userId)) {
-      setDebugLogs((logs) => [...logs, `🔎 Ищем UUID в profiles по telegramId ${userId}`]);
+    if (userId && /^\d+$/.test(String(userId))) {
+      userId = String(userId);
+      setDebugLogs((logs) => [
+        ...logs,
+        `🔎 Ищем UUID в profiles по telegramId ${userId}`
+      ]);
       const { data: profileData, error: profileError } = await supabase
         .from('profiles')
         .select('id')
-        .eq('telegram_id', String(userId))
+        .eq('telegram_id', userId)
         .maybeSingle();
 
       if (profileError) {


### PR DESCRIPTION
## Summary
- transform numeric userId into a string before querying profiles
- replace the numeric Telegram ID with the found UUID when saving progress

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687b8aab521c8324ad8318b334601916