### PR TITLE
Fix telegram_id query comparison

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -109,7 +109,7 @@ function App() {
       const { data: profileData, error: profileError } = await supabase
         .from('profiles')
         .select('id')
-        .eq('telegram_id', userId)
+        .eq('telegram_id', String(userId))
         .maybeSingle();
 
       if (profileError) {

--- a/src/components/SectionComplete.tsx
+++ b/src/components/SectionComplete.tsx
@@ -64,7 +64,7 @@ const SectionComplete: FC<SectionCompleteProps> = ({
         const { data: profile, error: profileError } = await supabase
           .from('profiles')
           .select('id')
-          .eq('telegram_id', userId)
+          .eq('telegram_id', String(userId))
           .maybeSingle();
 
         if (profileError) {


### PR DESCRIPTION
## Summary
- ensure telegram_id is compared as a string

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687b9da32dac8324b43f48844892137f