### PR TITLE
Add UUID validation before progress upsert

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -124,8 +124,12 @@ function App() {
       }
     }
 
-    if (!userId) {
-      setDebugLogs((logs) => [...logs, '❌ Нет user_id, прогресс не будет сохранён']);
+    if (!userId || /^\d+$/.test(String(userId))) {
+      setDebugLogs((logs) => [
+        ...logs,
+        '❌ Ошибка: userId не является UUID, прогресс не будет сохранён'
+      ]);
+      console.error('❌ Ошибка: userId не является UUID, прогресс не будет сохранён');
       return;
     }
 
@@ -145,6 +149,7 @@ function App() {
       ...logs,
       `📦 upsert data: ${JSON.stringify(upsertData)}`
     ]);
+    console.log('📦 upsert data:', upsertData);
 
     const { error } = await supabase
       .from('user_progress')

--- a/src/components/SectionComplete.tsx
+++ b/src/components/SectionComplete.tsx
@@ -79,21 +79,27 @@ const SectionComplete: FC<SectionCompleteProps> = ({
         }
       }
 
+      if (!userId || /^\d+$/.test(userId)) {
+        console.error('❌ Ошибка: userId не является UUID, прогресс не будет сохранён');
+        return;
+      }
+
+      const upsertData = [
+        {
+          user_id: userId,
+          section_id: sectionId,
+          chapter_id: chapterId,
+          accuracy: percentage,
+          completed,
+          updated_at: new Date().toISOString()
+        }
+      ];
+
+      console.log('📦 upsert data:', upsertData[0]);
+
       const { error } = await supabase
         .from('user_progress')
-        .upsert(
-          [
-            {
-              user_id: userId,
-              section_id: sectionId,
-              chapter_id: chapterId,
-              accuracy: percentage,
-              completed,
-              updated_at: new Date().toISOString()
-            }
-          ],
-          { onConflict: ['user_id', 'section_id'] }
-        );
+        .upsert(upsertData, { onConflict: ['user_id', 'section_id'] });
 
       if (error) {
         console.error('Ошибка сохранения прогресса:', error);


### PR DESCRIPTION
## Summary
- validate that user ID is UUID before inserting progress
- log upsert data for easier debugging

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687ba27c845083249b00ad798e5160b1