### PR TITLE
Save Telegram first_name as username

### DIFF
--- a/src/components/MyAccount.tsx
+++ b/src/components/MyAccount.tsx
@@ -272,6 +272,7 @@ const MyAccount: FC<MyAccountProps> = ({ onBackToHome, onStartChapter }) => {
   };
 
   const telegramUser = window.Telegram?.WebApp?.initDataUnsafe?.user;
+  const isTelegramUser = Boolean(telegramUser);
 
   useEffect(() => {
     if (!isAuthenticated && telegramUser) {
@@ -599,7 +600,11 @@ const MyAccount: FC<MyAccountProps> = ({ onBackToHome, onStartChapter }) => {
                 <User className="w-8 h-8 text-white" />
               </div>
               <div>
-                {isEditingUsername ? (
+                {isTelegramUser ? (
+                  <h1 className="text-2xl font-bold text-emerald-900">
+                    {profile?.username || 'Пользователь'}
+                  </h1>
+                ) : isEditingUsername ? (
                   <div className="flex items-center space-x-2">
                     <input
                       type="text"

--- a/src/components/TelegramLoginRedirect.tsx
+++ b/src/components/TelegramLoginRedirect.tsx
@@ -17,22 +17,29 @@ const TelegramLoginRedirect = () => {
     }
 
     const userId = telegramUser.id.toString();
+    const firstName = telegramUser.first_name;
 
     const initProfile = async () => {
       try {
         const { data } = await supabase
           .from('profiles')
-          .select('id')
+          .select('id, username')
           .eq('id', userId)
-          .single();
+          .maybeSingle();
 
         if (!data) {
           await supabase.from('profiles').insert({
             id: userId,
-            username: telegramUser.username,
-            email: `${telegramUser.username}@telegram`,
+            username: firstName,
+            email: `${userId}@telegram`,
+            telegram_id: userId,
             created_at: new Date().toISOString(),
           });
+        } else if (!data.username) {
+          await supabase
+            .from('profiles')
+            .update({ username: firstName })
+            .eq('id', userId);
         }
 
         localStorage.setItem('user_id', userId);

--- a/src/hooks/useSupabaseAuth.js
+++ b/src/hooks/useSupabaseAuth.js
@@ -38,7 +38,7 @@ export function useSupabaseAuth() {
       setLoading(true)
       setError(null)
 
-      if (!profileCheckedRef.current) {
+      if (!profileCheckedRef.current && currentUser.email) {
         profileCheckedRef.current = true
         await ensureUserProfile(currentUser)
       }


### PR DESCRIPTION
## Summary
- update Telegram login redirect to store Telegram first_name into `profiles.username`
- avoid calling `ensureUserProfile` for local telegram users
- prevent editing username in account page when coming from Telegram

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687bc8f0d4d0832488a9be24f9a715c3