### PR TITLE
Add isAdmin to auth context

### DIFF
--- a/src/components/MyAccount.tsx
+++ b/src/components/MyAccount.tsx
@@ -53,11 +53,6 @@ const MyAccount: FC<MyAccountProps> = ({ onBackToHome, onStartChapter }) => {
   const [progressData, setProgressData] = useState<any[]>([]);
   const [chapterProgress, setChapterProgress] = useState<any[]>([]);
   const [recommendedChapter, setRecommendedChapter] = useState<{ chapterId: number; title: string } | null>(null);
-  const [userStats, setUserStats] = useState({
-    completedSections: 0,
-    averageAccuracy: 0,
-    totalTimeSpent: 0
-  });
   const [completedChapters, setCompletedChapters] = useState(0);
   const [totalStudyMinutes, setTotalStudyMinutes] = useState(0);
   const [averageAccuracy, setAverageAccuracy] = useState(0);

--- a/src/components/SupabaseAuthProvider.tsx
+++ b/src/components/SupabaseAuthProvider.tsx
@@ -10,6 +10,7 @@ export interface AuthContextValue {
   loading: boolean
   error: string | null
   isAuthenticated: boolean
+  isAdmin: boolean
   signIn: (email: string, password: string) => Promise<unknown>
   signUp: (email: string, password: string, username: string) => Promise<unknown>
   signOut: () => Promise<void>
@@ -27,10 +28,15 @@ const SupabaseAuthContext = createContext<AuthContextValue | null>(null)
  * @param {React.ReactNode} props.children - Дочерние компоненты
  */
 export function SupabaseAuthProvider({ children }: { children: ReactNode }) {
-  const auth = useAuthHook() as unknown as AuthContextValue
+  const auth = useAuthHook() as unknown as Omit<AuthContextValue, 'isAdmin'> & {
+    profile: { is_admin?: boolean }
+  }
+
+  const isAdmin = Boolean(auth.profile?.is_admin)
+  const value = { ...auth, isAdmin } as AuthContextValue
 
   return (
-    <SupabaseAuthContext.Provider value={auth}>
+    <SupabaseAuthContext.Provider value={value}>
       {children}
     </SupabaseAuthContext.Provider>
   )


### PR DESCRIPTION
## Summary
- expose `isAdmin` flag in `SupabaseAuthProvider`
- remove unused variable in `MyAccount`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687bd10d5edc83249af080dac0f1f53e