### PR TITLE
Improve section list visuals

### DIFF
--- a/src/components/ChaptersList.tsx
+++ b/src/components/ChaptersList.tsx
@@ -358,9 +358,12 @@ const ChaptersList: FC<ChaptersListProps> = ({ onChapterSelect, currentUser = ''
               </button>
 
               {openChapterId === chapter.id && (
-                <ul className="mt-4 space-y-1 text-left">
+                <ul className="mt-4 space-y-2 text-left">
                   {sectionsByChapter[chapter.id]?.map((section) => (
-                    <li key={section.id} className="border-t border-emerald-200 pt-2 text-sm text-emerald-800">
+                    <li
+                      key={section.id}
+                      className="max-w-[90%] ml-4 border-l-4 border-green-400 rounded-lg bg-gray-50 shadow-sm px-3 py-2 text-sm text-emerald-800"
+                    >
                       {section.title}
                     </li>
                   ))}


### PR DESCRIPTION
## Summary
- render chapter sections as nested cards so they look distinct

## Testing
- `npm test`
- `npm run lint` *(fails: warnings only)*

------
https://chatgpt.com/codex/tasks/task_e_687be312f2e883249cbf1d15ae06a9ca