### PR TITLE
Fix lint error in ChapterCard regex

### DIFF
--- a/src/components/ChapterCard.tsx
+++ b/src/components/ChapterCard.tsx
@@ -12,8 +12,8 @@ interface ChapterCardProps {
 // Remove common prefixes like "Глава 1" or "1." from the title
 const cleanTitle = (title: string): string => {
   return title
-    .replace(/^\s*Глава\s*\d+[:.\-]?\s*/i, '')
-    .replace(/^\s*\d+[:.\-]?\s*/, '')
+    .replace(/^\s*Глава\s*\d+[:.-]?\s*/i, '')
+    .replace(/^\s*\d+[:.-]?\s*/, '')
     .trim();
 };
 


### PR DESCRIPTION
## Summary
- remove unnecessary escapes in ChapterCard regex

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687c1c8d77588324ad5facd35569a2c0