### PR TITLE
Implement failed section redirect

### DIFF
--- a/src/components/ChapterCard.tsx
+++ b/src/components/ChapterCard.tsx
@@ -12,8 +12,8 @@ interface ChapterCardProps {
 // Remove common prefixes like "Глава 1" or "1." from the title
 const cleanTitle = (title: string): string => {
   return title
-    .replace(/^\s*Глава\s*\d+[:.\-]?\s*/i, '')
-    .replace(/^\s*\d+[:.\-]?\s*/, '')
+    .replace(/^\s*Глава\s*\d+[:.-]?\s*/i, '')
+    .replace(/^\s*\d+[:.-]?\s*/, '')
     .trim();
 };
 

--- a/src/components/SectionComplete.tsx
+++ b/src/components/SectionComplete.tsx
@@ -2,6 +2,7 @@ import { FC, useEffect } from 'react';
 import type { QuestionResultItem } from './QuestionInterface';
 import { CheckCircle, XCircle, RotateCcw, ArrowRight, Trophy, Clock } from 'lucide-react';
 import { supabase } from '../services/supabaseClient.js';
+import SectionFailed from './SectionFailed';
 
 interface SectionResults {
   totalQuestions: number;
@@ -29,6 +30,7 @@ const SectionComplete: FC<SectionCompleteProps> = ({
 }) => {
   const percentage = Math.round((results.correctAnswers / results.totalQuestions) * 100);
   const incorrectCount = results.incorrectAnswers.length;
+  const accuracy = results.totalQuestions > 0 ? results.correctAnswers / results.totalQuestions : 0;
 
   const getPerformanceMessage = () => {
     if (percentage >= 90) return { message: "Отличная работа!", color: "text-green-600", icon: Trophy };
@@ -128,6 +130,10 @@ const SectionComplete: FC<SectionCompleteProps> = ({
 
     saveSectionProgress();
   }, []);
+
+  if (accuracy < 0.7) {
+    return <SectionFailed sectionId={String(sectionId)} />;
+  }
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-green-50 to-green-100 p-6">

--- a/src/components/SectionFailed.tsx
+++ b/src/components/SectionFailed.tsx
@@ -6,7 +6,6 @@ import videoFile from '../assets/Failed.mp4'; // убедись, что файл
 
 const SectionFailed = ({ sectionId }: { sectionId: string }) => {
   const [showRetry, setShowRetry] = useState(false);
-  const [buttonLabel, setButtonLabel] = useState('Загрузка');
   const [dots, setDots] = useState('');
   const navigate = useNavigate();
 


### PR DESCRIPTION
## Summary
- add missing SectionFailed import and early return when accuracy below 70%
- remove unused state from SectionFailed
- clean up regex escapes in ChapterCard
- run ESLint and unit tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687c22dc8fcc832483e03e9a9790aca4