### PR TITLE
Add start video loader during initial load

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,7 +123,18 @@
     <div id="loading">
       <div class="loading-spinner"></div>
     </div>
-    
+
+    <!-- Start video loader -->
+    <div id="start-loader" style="position: fixed; inset: 0; z-index: 9999; background: black;">
+      <video
+        src="/start-loading.mp4"
+        autoplay
+        muted
+        playsinline
+        style="width: 100%; height: 100%; object-fit: cover"
+      ></video>
+    </div>
+
     <div id="root"></div>
     
     <script>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -43,3 +43,7 @@ root.render(
 
 // Hide loading screen after React renders
 window.setTimeout(hideLoadingScreen, 100);
+
+// Remove start video loader once React has mounted
+const startLoader = document.getElementById('start-loader');
+if (startLoader) startLoader.remove();


### PR DESCRIPTION
## Summary
- show a fullscreen start-loading.mp4 video before the React app mounts
- remove the start video loader after mounting

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687c31ae7fdc8324832be5649bba1c3c