### PR TITLE
Implement Supabase login for Telegram users

### DIFF
--- a/src/services/telegramAuth.ts
+++ b/src/services/telegramAuth.ts
@@ -1,8 +1,8 @@
 import { supabase } from './supabaseClient.js';
-import { v5 as uuidv5 } from 'uuid';
 import { telegramWebApp } from './telegramWebApp';
 
-const TELEGRAM_NAMESPACE = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
+const PASSWORD_SUFFIX = '_tg';
+
 
 export async function telegramLogin() {
   if (!window.Telegram?.WebApp) {
@@ -21,13 +21,42 @@ export async function telegramLogin() {
   const telegramId = user.id.toString();
   const username = user.username || `${user.first_name}${user.last_name || ''}`;
   const email = `${telegramId}@telegram.local`;
-  const userUUID = uuidv5(telegramId, TELEGRAM_NAMESPACE);
+  const password = telegramId + PASSWORD_SUFFIX;
+
+  let authUserId = null;
+
+  try {
+    const { data: signUpData, error: signUpError } = await supabase.auth.signUp({
+      email,
+      password
+    });
+
+    if (signUpError && !signUpError.message.includes('User already registered')) {
+      throw signUpError;
+    }
+
+    if (signUpData?.user) {
+      authUserId = signUpData.user.id;
+    } else {
+      const { data: signInData, error: signInError } =
+        await supabase.auth.signInWithPassword({ email, password });
+      if (signInError) throw signInError;
+      authUserId = signInData.user.id;
+    }
+  } catch (err) {
+    console.error('❌ Ошибка входа через Supabase:', err);
+  }
+
+  if (!authUserId) {
+    console.warn('Supabase auth user not created');
+    return null;
+  }
 
   const { data, error } = await supabase
     .from('profiles')
     .upsert(
       {
-        id: userUUID,
+        id: authUserId,
         telegram_id: telegramId,
         username: username || `${user.first_name || ''} ${user.last_name || ''}`.trim(),
         email
@@ -43,8 +72,11 @@ export async function telegramLogin() {
     console.log('✅ Профиль создан или обновлён:', data);
   }
 
-  localStorage.setItem('user_id', userUUID);
-  return { id: userUUID, username, email };
+  localStorage.setItem('user_id', authUserId);
+  localStorage.setItem('user_email', email);
+  localStorage.setItem('user_password', password);
+  localStorage.setItem('telegram_id', telegramId);
+  return { id: authUserId, username, email };
 }
 
 export function getStoredUser() {


### PR DESCRIPTION
## Summary
- create Supabase auth account in `telegramLogin`
- add auth handling in `findOrCreateUserProfile`
- load session in `getCurrentUser`
- store login credentials for auto sign‑in

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687cb56ace188324bdf2267f80c31abd