### PR TITLE
Load admin credentials from env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,5 @@ VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
 
 # Admin Login
 VITE_ADMIN_PASSWORD=admin
+VITE_ADMIN_USERNAME=admin
+VITE_ADMIN_EMAIL=admin@example.com

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -274,7 +274,7 @@ function App() {
     { id: 'account', label: 'Мой аккаунт', icon: User }
   ];
 
-  // Добавляем кнопку "Админ" только для admin5050
+  // Добавляем кнопку "Админ" только для пользователей из ADMIN_USERNAMES
   const navigationItems = hasAdminAccess() 
     ? [...baseNavigationItems, { id: 'admin', label: 'Админ', icon: Settings }]
     : baseNavigationItems;

--- a/src/utils/adminUtils.ts
+++ b/src/utils/adminUtils.ts
@@ -1,5 +1,12 @@
-export const ADMIN_USERNAMES = ['admin5050', 'admin', 'administrator'];
-export const ADMIN_EMAILS = ['admin5050@gmail.com'];
+const USERNAME_ENV = import.meta.env.VITE_ADMIN_USERNAME || ''
+const EMAIL_ENV = import.meta.env.VITE_ADMIN_EMAIL || ''
+
+export const ADMIN_USERNAMES = USERNAME_ENV
+  ? USERNAME_ENV.split(',').map((u) => u.trim().toLowerCase())
+  : []
+export const ADMIN_EMAILS = EMAIL_ENV
+  ? EMAIL_ENV.split(',').map((e) => e.trim().toLowerCase())
+  : []
 
 export function isAdmin(username?: string | null, email?: string | null): boolean {
   const uname = username?.toLowerCase() || '';


### PR DESCRIPTION
## Summary
- use environment variables for admin usernames and emails
- mention env vars in docs
- clarify navigation comment

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687cbab0b8348324bb50f56a3fba0005