### PR TITLE
Use RPC for Telegram profile creation

### DIFF
--- a/src/components/TelegramLoginRedirect.tsx
+++ b/src/components/TelegramLoginRedirect.tsx
@@ -22,26 +22,14 @@ const TelegramLoginRedirect = () => {
 
     const initProfile = async () => {
       try {
-        const { data } = await supabase
-          .from('profiles')
-          .select('id, username')
-          .eq('id', userId)
-          .maybeSingle();
+        const { error } = await supabase.rpc('create_user_from_telegram', {
+          uid: userId,
+          username: firstName,
+          email: `${userId}@telegram`,
+          telegram_id: userId,
+        });
 
-        if (!data) {
-          await supabase.from('profiles').insert({
-            id: userId,
-            username: firstName,
-            email: `${userId}@telegram`,
-            telegram_id: userId,
-            created_at: new Date().toISOString(),
-          });
-        } else if (!data.username) {
-          await supabase
-            .from('profiles')
-            .update({ username: firstName })
-            .eq('id', userId);
-        }
+        if (error) throw error;
 
         localStorage.setItem('user_id', userId);
         setLoading(false);

--- a/src/services/telegramAuth.ts
+++ b/src/services/telegramAuth.ts
@@ -52,24 +52,17 @@ export async function telegramLogin() {
     return null;
   }
 
-  const { data, error } = await supabase
-    .from('profiles')
-    .upsert(
-      {
-        id: authUserId,
-        telegram_id: telegramId,
-        username: username || `${user.first_name || ''} ${user.last_name || ''}`.trim(),
-        email
-      },
-      {
-        onConflict: ['telegram_id']
-      }
-    );
+  const { error: rpcError } = await supabase.rpc('create_user_from_telegram', {
+    uid: authUserId,
+    username: username || `${user.first_name || ''} ${user.last_name || ''}`.trim(),
+    email,
+    telegram_id: telegramId
+  });
 
-  if (error) {
-    console.error('❌ Ошибка при сохранении профиля в Supabase:', error.message);
+  if (rpcError) {
+    console.error('❌ Ошибка при сохранении профиля в Supabase:', rpcError.message);
   } else {
-    console.log('✅ Профиль создан или обновлён:', data);
+    console.log('✅ Профиль создан или обновлён через RPC');
   }
 
   localStorage.setItem('user_id', authUserId);


### PR DESCRIPTION
## Summary
- switch Telegram login flow to use `create_user_from_telegram` RPC
- do the same during Telegram WebApp login via `telegramAuth` service

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687cc0ace4148324895fffa054fd1400