### PR TITLE
Refactor progress and profile fetching

### DIFF
--- a/src/hooks/useUserProfile.ts
+++ b/src/hooks/useUserProfile.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react'
+import { useAuth } from '../components/SupabaseAuthProvider'
+import { getUserProfile } from '../services/authService.js'
+
+export interface UserProfile {
+  id: string
+  [key: string]: any
+}
+
+const useUserProfile = (userId?: string | null) => {
+  const { user, profile: authProfile, updateProfile } = useAuth() as any
+  const resolvedId = userId || user?.id || localStorage.getItem('user_id') || null
+  const [profile, setProfile] = useState<UserProfile | null>(
+    authProfile && (!userId || authProfile?.id === resolvedId) ? authProfile : null
+  )
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    const load = async () => {
+      if (!resolvedId) {
+        setProfile(null)
+        return
+      }
+      if (authProfile && authProfile.id === resolvedId) {
+        setProfile(authProfile)
+        return
+      }
+      setLoading(true)
+      const data = await getUserProfile(resolvedId)
+      setProfile(data)
+      setLoading(false)
+    }
+    void load()
+  }, [resolvedId, authProfile])
+
+  return { userId: resolvedId, profile, loading, updateProfile }
+}
+
+export default useUserProfile

--- a/src/hooks/useUserProgress.ts
+++ b/src/hooks/useUserProgress.ts
@@ -18,6 +18,7 @@ export const useUserProgress = (userId?: string | null) => {
   const [chapterProgress, setChapterProgress] = useState<ChapterProgress[]>([])
   const [recommendedChapter, setRecommendedChapter] = useState<{chapterId:number; title:string} | null>(null)
   const [progressData, setProgressData] = useState<any[]>([])
+  const [sectionProgressMap, setSectionProgressMap] = useState<Record<number, { accuracy: number; completed: boolean }>>({})
 
   useEffect(() => {
     const fetchStart = async () => {
@@ -139,6 +140,19 @@ export const useUserProgress = (userId?: string | null) => {
   }, [userId])
 
   useEffect(() => {
+    const map: Record<number, { accuracy: number; completed: boolean }> = {}
+    progressData.forEach((row: any) => {
+      if (row.section_id && !row.question_id) {
+        map[row.section_id] = {
+          accuracy: row.accuracy ?? 0,
+          completed: row.completed ?? false
+        }
+      }
+    })
+    setSectionProgressMap(map)
+  }, [progressData])
+
+  useEffect(() => {
     const fetchChapterProgress = async () => {
       if (!userId) return
 
@@ -210,7 +224,8 @@ export const useUserProgress = (userId?: string | null) => {
     averageAccuracy,
     chapterProgress,
     recommendedChapter,
-    progressData
+    progressData,
+    sectionProgressMap
   }
 }
 


### PR DESCRIPTION
## Summary
- add `useUserProfile` hook for profile retrieval
- extend `useUserProgress` with `sectionProgressMap`
- update `SectionsList` to use new hooks and remove direct Supabase queries

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687cc517077c8324a35966baf1e8b3b7