### PR TITLE
Improve layout for chapters and sections

### DIFF
--- a/src/components/ChapterCard.tsx
+++ b/src/components/ChapterCard.tsx
@@ -25,8 +25,8 @@ const ChapterCard: FC<ChapterCardProps> = ({ number, title, subtitle, level, onS
       <div className="w-10 h-10 rounded-full bg-green-500 text-white flex items-center justify-center text-lg font-bold mb-2">
         {number}
       </div>
-      <h3 className="text-base font-semibold leading-snug">{displayTitle}</h3>
-      {subtitle && <p className="text-sm text-gray-600 mt-1">{subtitle}</p>}
+      <h3 className="text-base font-semibold leading-snug text-ellipsis">{displayTitle}</h3>
+      {subtitle && <p className="text-sm text-gray-600 mt-1 text-ellipsis">{subtitle}</p>}
       {level && (
         <span className="text-xs mt-2 inline-block bg-emerald-100 text-emerald-700 rounded-full px-2 py-0.5">
           {level}
@@ -34,7 +34,7 @@ const ChapterCard: FC<ChapterCardProps> = ({ number, title, subtitle, level, onS
       )}
       <button
         onClick={onStart}
-        className="mt-4 w-full py-2 px-4 rounded-lg flex items-center justify-center gap-2 bg-green-600 text-white font-semibold shadow-sm hover:bg-green-700 hover:scale-105 hover:shadow-md transition-transform duration-200 active:scale-100"
+        className="mt-4 max-w-xs w-full px-4 py-2 rounded-lg flex items-center justify-center gap-2 bg-green-600 text-white font-semibold shadow-sm hover:bg-green-700 hover:scale-105 hover:shadow-md transition-transform duration-200 active:scale-100"
       >
         <Play className="w-4 h-4" />
         <span>Начать</span>

--- a/src/components/ChaptersList.tsx
+++ b/src/components/ChaptersList.tsx
@@ -193,7 +193,7 @@ const ChaptersList: FC<ChaptersListProps> = ({ onChapterSelect, currentUser = ''
   }
 
   return (
-    <div className="p-6 pt-2 space-y-6 mx-auto max-w-screen-sm">
+    <div className="min-h-screen mx-auto max-w-screen-sm p-4 sm:p-6 space-y-6">
       {/* Header */}
       <div className="text-center mb-8">
         <h1 className="text-3xl font-bold text-emerald-900 mb-2">Изучение эсперанто</h1>
@@ -246,16 +246,16 @@ const ChaptersList: FC<ChaptersListProps> = ({ onChapterSelect, currentUser = ''
           </div>
           <div>
             <h4
-              className="font-semibold text-emerald-900 break-words"
+              className="font-semibold text-emerald-900 break-words text-ellipsis"
               style={{ textWrap: 'balance' }}
             >
               {recommendedChapter.title}
             </h4>
-            <p className="text-sm text-emerald-700 break-words">{recommendedChapter.description}</p>
+            <p className="text-sm text-emerald-700 break-words text-ellipsis">{recommendedChapter.description}</p>
           </div>
           <button
             onClick={() => onChapterSelect(recommendedChapter.id)}
-            className="w-full py-2 px-4 rounded-lg flex items-center justify-center gap-2 bg-green-600 text-white font-semibold shadow-sm hover:bg-green-700 hover:scale-105 hover:shadow-md transition-transform duration-200 active:scale-100 box-border"
+            className="max-w-xs w-full px-4 py-2 rounded-lg flex items-center justify-center gap-2 bg-green-600 text-white font-semibold shadow-sm hover:bg-green-700 hover:scale-105 hover:shadow-md transition-transform duration-200 active:scale-100 box-border"
           >
             <Play className="w-4 h-4" />
             <span>Начать</span>
@@ -319,7 +319,7 @@ const ChaptersList: FC<ChaptersListProps> = ({ onChapterSelect, currentUser = ''
                 {chapter.isLocked && !hasAdminAccess() ? <Lock className="w-6 h-6" /> : chapter.id}
               </div>
 
-              <h3 className="text-lg font-semibold text-emerald-900 break-words" style={{ textWrap: 'balance' }}>
+              <h3 className="text-lg font-semibold text-emerald-900 break-words text-ellipsis" style={{ textWrap: 'balance' }}>
                 {chapter.title}
               </h3>
 
@@ -334,7 +334,7 @@ const ChaptersList: FC<ChaptersListProps> = ({ onChapterSelect, currentUser = ''
                   onChapterSelect(chapter.id);
                 }}
                 disabled={chapter.isLocked && !hasAdminAccess()}
-                className={`w-full py-2 px-4 rounded-lg flex items-center justify-center gap-2 font-semibold transition-transform duration-200 box-border ${
+                className={`max-w-xs w-full px-4 py-2 rounded-lg flex items-center justify-center gap-2 font-semibold transition-transform duration-200 box-border ${
                   chapter.isLocked && !hasAdminAccess()
                     ? 'bg-gray-300 text-gray-500 cursor-not-allowed'
                     : 'bg-green-600 text-white shadow hover:bg-green-700 hover:scale-105 active:scale-100'
@@ -363,7 +363,7 @@ const ChaptersList: FC<ChaptersListProps> = ({ onChapterSelect, currentUser = ''
                   {sectionsByChapter[chapter.id]?.map((section) => (
                     <li
                       key={section.id}
-                      className="max-w-[90%] ml-4 border-l-4 border-green-400 rounded-lg bg-gray-50 shadow-sm px-3 py-2 text-sm text-emerald-800"
+                      className="max-w-[90%] ml-4 border-l-4 border-green-400 rounded-lg bg-gray-50 shadow-sm px-3 py-2 text-sm text-emerald-800 text-ellipsis"
                     >
                       {section.title}
                     </li>

--- a/src/components/SectionsList.tsx
+++ b/src/components/SectionsList.tsx
@@ -92,7 +92,7 @@ const SectionsList: FC<SectionsListProps> = ({ chapterId, onSectionSelect, onBac
   }
 
   return (
-    <div className="w-full max-w-screen-sm mx-auto px-4 space-y-4 pt-20">
+    <div className="min-h-screen w-full max-w-screen-sm mx-auto px-4 sm:px-6 pt-20 space-y-4">
       <div className="flex items-center space-x-4 mb-6">
         <button
           onClick={onBackToChapters}
@@ -182,7 +182,7 @@ const SectionsList: FC<SectionsListProps> = ({ chapterId, onSectionSelect, onBac
                   </div>
                   <div>
                     <h3
-                      className="text-lg font-semibold text-emerald-900 break-words"
+                      className="text-lg font-semibold text-emerald-900 break-words text-ellipsis"
                       style={{ textWrap: 'balance' }}
                     >
                       {section.title}


### PR DESCRIPTION
## Summary
- make main course views min-h-screen and responsive
- scale buttons and truncate long titles in lists
- limit card title lengths and scale button widths

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687cc716c1b88324a182eed51b7ac011