### PR TITLE
Store telegram id after login

### DIFF
--- a/src/components/MyAccount.tsx
+++ b/src/components/MyAccount.tsx
@@ -98,11 +98,13 @@ const MyAccount: FC<MyAccountProps> = ({ onBackToHome, onStartChapter }) => {
 
     if (!userId) {
       setLoginError('Ошибка создания профиля')
-    } else {
-      localStorage.setItem('user_id', userId)
-      await refreshStats()
+      return
     }
-    setLoginLoading(false)
+
+    // ✅ сохраняем telegram_id
+    localStorage.setItem('user_id', tgUser.id.toString())
+
+    window.location.reload()
   }
 
   const telegramUser = window.Telegram?.WebApp?.initDataUnsafe?.user


### PR DESCRIPTION
## Summary
- store telegram user id in local storage on login so app can load data by Telegram ID

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687cdabb548c8324b57b66149a5f0c41