### PR TITLE
Fix video autoplay and login reload

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,6 +132,7 @@
         autoplay
         muted
         playsinline
+        loop
         onended="window.hideLoadingScreen()"
         style="width: 100%; height: 100%; object-fit: cover"
       ></video>

--- a/src/components/MyAccount.tsx
+++ b/src/components/MyAccount.tsx
@@ -104,7 +104,7 @@ const MyAccount: FC<MyAccountProps> = ({ onBackToHome, onStartChapter }) => {
     // ✅ сохраняем telegram_id
     localStorage.setItem('user_id', tgUser.id.toString())
 
-    window.location.reload()
+    navigate('/')
   }
 
   const telegramUser = window.Telegram?.WebApp?.initDataUnsafe?.user


### PR DESCRIPTION
## Summary
- autoplay intro video on start
- avoid infinite reload after Telegram login

## Testing
- `npm test`
- `npm run lint` *(fails: 11 errors, 9 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_687ce4c9d7ac8324a26be96b15408b7f