### PR TITLE
Ensure autoplay for videos

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,6 +132,7 @@
         autoplay
         muted
         playsinline
+        preload="auto"
         onended="window.hideLoadingScreen()"
         style="width: 100%; height: 100%; object-fit: cover"
       ></video>
@@ -175,7 +176,11 @@
           }
         };
 
-        tryPlay();
+        if (video.readyState >= 2) {
+          tryPlay();
+        } else {
+          video.addEventListener('canplay', tryPlay, { once: true });
+        }
       });
 
       // Universal Links Detection and Handling

--- a/src/components/LoadingVideo.tsx
+++ b/src/components/LoadingVideo.tsx
@@ -9,6 +9,7 @@ const LoadingVideo: React.FC = () => (
       muted
       loop
       playsInline
+      preload="auto"
       className="w-full h-full object-cover"
     />
   </div>

--- a/src/components/SectionFailed.tsx
+++ b/src/components/SectionFailed.tsx
@@ -39,6 +39,7 @@ const SectionFailed = ({ sectionId, delay = 2000, onRetry }: SectionFailedProps)
         autoPlay
         muted
         playsInline
+        preload="auto"
         className="absolute top-0 left-0 w-full h-full object-cover"
       />
       <div className="absolute bottom-[12%] left-1/2 transform -translate-x-1/2 text-center px-4 w-full max-w-xs">

--- a/src/components/SectionSuccess.tsx
+++ b/src/components/SectionSuccess.tsx
@@ -49,6 +49,7 @@ const SectionSuccess = ({
         autoPlay
         muted
         playsInline
+        preload="auto"
         className="absolute top-0 left-0 w-full h-full object-cover"
       />
       <div className="absolute bottom-[12%] left-1/2 transform -translate-x-1/2 text-center px-4 w-full max-w-xs">


### PR DESCRIPTION
## Summary
- make intro video autoplay after `canplay` event
- preload intro video
- preload SectionFailed/Success and LoadingVideo components

## Testing
- `npm test`
- `npm run lint` *(fails: cannot find '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687cfc4880348324aa60548f1ac7b0b8