### PR TITLE
Auto-play splash video on app start

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,19 +124,7 @@
       <div class="loading-spinner"></div>
     </div>
 
-    <!-- Start video loader -->
-    <div id="start-loader" style="position: fixed; inset: 0; z-index: 9999; background: black;">
-      <video
-        id="loadingVideo"
-        src="/start-loading.mp4"
-        autoplay
-        muted
-        playsinline
-        preload="auto"
-        onended="window.hideLoadingScreen()"
-        style="width: 100%; height: 100%; object-fit: cover"
-      ></video>
-    </div>
+    <!-- Placeholder for React splash screen -->
 
     <div id="root"></div>
     
@@ -150,38 +138,7 @@
             loadingElement.style.display = 'none';
           }, 300);
         }
-
-        const startLoader = document.getElementById('start-loader');
-        if (startLoader) {
-          startLoader.remove();
-        }
       }
-
-      // Attempt to autoplay the intro video on page load
-      document.addEventListener('DOMContentLoaded', function () {
-        const video = document.getElementById('loadingVideo');
-        if (!video || typeof video.play !== 'function') return;
-
-        const tryPlay = () => {
-          const playPromise = video.play();
-          if (playPromise !== undefined) {
-            playPromise.catch((err) => {
-              console.error('Intro video failed to play:', err);
-              // Fallback: play on first user interaction
-              const resume = () => {
-                video.play().catch((err2) => console.error('Retry failed:', err2));
-              };
-              document.addEventListener('click', resume, { once: true });
-            });
-          }
-        };
-
-        if (video.readyState >= 2) {
-          tryPlay();
-        } else {
-          video.addEventListener('canplay', tryPlay, { once: true });
-        }
-      });
 
       // Universal Links Detection and Handling
       function detectTelegramWebApp() {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@ import TestResults from './components/TestResults';
 import AIChat from './components/AIChat';
 import MyAccount from './components/MyAccount';
 import AdminPanel from './components/AdminPanel';
+import SplashScreen from './components/SplashScreen';
 import { useAuth } from './components/SupabaseAuthProvider';
 import { saveTestResults } from './services/progressService';
 import { supabase } from './services/supabaseClient.js';
@@ -42,6 +43,11 @@ import { isAdmin } from './utils/adminUtils.js';
 function App() {
   const [isVisible, setIsVisible] = useState(false);
   const [activeTab, setActiveTab] = useState('home');
+  const [showSplash, setShowSplash] = useState(true);
+
+  const handleSplashEnd = () => {
+    setShowSplash(false);
+  };
 
   useEffect(() => {
     const isTelegramWebApp = window?.Telegram?.WebApp?.initData;
@@ -472,6 +478,11 @@ function App() {
       </nav>
     );
   };
+
+  // Show intro splash video
+  if (showSplash) {
+    return <SplashScreen onFinish={handleSplashEnd} />;
+  }
 
   // Render Admin Panel
   if (showAdminPanel) {

--- a/src/components/SplashScreen.tsx
+++ b/src/components/SplashScreen.tsx
@@ -1,0 +1,56 @@
+import { useRef, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+interface SplashScreenProps {
+  onFinish: () => void;
+}
+
+// Expose window.hideLoadingScreen typing
+declare global {
+  interface Window {
+    hideLoadingScreen?: () => void;
+  }
+}
+
+const SplashScreen: React.FC<SplashScreenProps> = ({ onFinish }) => {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video) return;
+    const playPromise = video.play();
+    if (playPromise !== undefined) {
+      playPromise.catch(() => {
+        const resume = () => {
+          video.play().catch(() => {});
+        };
+        document.addEventListener('click', resume, { once: true });
+      });
+    }
+  }, []);
+
+  const handleEnd = () => {
+    if (window.hideLoadingScreen) {
+      window.hideLoadingScreen();
+    }
+    onFinish();
+    navigate('/');
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black">
+      <video
+        ref={videoRef}
+        autoPlay
+        playsInline
+        muted
+        onEnded={handleEnd}
+        className="w-full h-screen object-cover"
+        src="/start-loading.mp4"
+      />
+    </div>
+  );
+};
+
+export default SplashScreen;


### PR DESCRIPTION
## Summary
- replace HTML intro loader with React-based `SplashScreen`
- create `SplashScreen` component with auto-playing video
- show `SplashScreen` in `App` until video finishes
- adjust `index.html` to remove static loader

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687d0169d710832494920aa324df4208