### PR TITLE
Improve logs around section progress upsert

### DIFF
--- a/src/components/SectionComplete.tsx
+++ b/src/components/SectionComplete.tsx
@@ -85,14 +85,16 @@ const SectionComplete: FC<SectionCompleteProps> = ({
         }
       ];
 
-      console.log('📦 upsert data:', upsertData[0]);
+      console.log('upsertData', upsertData);
+      console.log('user_id', userId);
 
-      const { error } = await supabase
+      const { data, error } = await supabase
         .from('user_progress')
         .upsert(upsertData, { onConflict: ['user_id', 'section_id', 'question_id'] });
 
+      console.log('user_progress upsert result:', data, error);
       if (error) {
-        console.error('Ошибка сохранения прогресса:', error);
+        console.error(error);
       } else {
         console.log('Прогресс раздела успешно сохранён.');
         try {


### PR DESCRIPTION
## Summary
- log the upsert data and user id before saving section progress
- print result of `user_progress` upsert

## Testing
- `npm run lint` *(fails: 11 errors, 9 warnings)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d03be2d248324bd2abe34f931c1d1