### PR TITLE
Fix splash video autoplay

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,6 +140,8 @@
         }
       }
 
+      window.hideLoadingScreen = hideLoadingScreen;
+
       // Universal Links Detection and Handling
       function detectTelegramWebApp() {
         const urlParams = new URLSearchParams(window.location.search);

--- a/src/components/SplashScreen.tsx
+++ b/src/components/SplashScreen.tsx
@@ -43,12 +43,14 @@ const SplashScreen: React.FC<SplashScreenProps> = ({ onFinish }) => {
       <video
         ref={videoRef}
         autoPlay
-        playsInline
         muted
+        playsInline
+        preload="auto"
         onEnded={handleEnd}
         className="w-full h-screen object-cover"
-        src="/start-loading.mp4"
-      />
+      >
+        <source src="/start-loading.mp4" type="video/mp4" />
+      </video>
     </div>
   );
 };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -20,6 +20,9 @@ function hideLoadingScreen() {
   }
 }
 
+// Expose helper for React components (SplashScreen)
+window.hideLoadingScreen = hideLoadingScreen;
+
 const root = createRoot(document.getElementById('root')!);
 
 root.render(


### PR DESCRIPTION
## Summary
- ensure SplashScreen video plays automatically and hides on end
- expose `hideLoadingScreen` globally for use by SplashScreen

## Testing
- `npm run lint` *(fails: unused vars in unrelated files)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687d06d82d548324987efc2843b366af