### PR TITLE
Show startup video instead of spinner

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,39 +73,6 @@
         padding-bottom: env(safe-area-inset-bottom);
       }
       
-      /* Loading screen */
-      #loading {
-        position: fixed;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        background: linear-gradient(135deg, #ecfdf5 0%, #f0fdf4 100%);
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        z-index: 9999;
-        transition: opacity 0.3s ease;
-      }
-      
-      #loading.hidden {
-        opacity: 0;
-        pointer-events: none;
-      }
-      
-      .loading-spinner {
-        width: 50px;
-        height: 50px;
-        border: 4px solid #d1fae5;
-        border-top: 4px solid #059669;
-        border-radius: 50%;
-        animation: spin 1s linear infinite;
-      }
-      
-      @keyframes spin {
-        0% { transform: rotate(0deg); }
-        100% { transform: rotate(360deg); }
-      }
       
       /* Universal Links Support */
       .universal-link {
@@ -119,30 +86,12 @@
       <a href="https://t.me/EsperantoLetoBot/webapp" id="telegram-link">Open in Telegram</a>
     </div>
     
-    <!-- Loading Screen -->
-    <div id="loading">
-      <div class="loading-spinner"></div>
-    </div>
-
     <!-- Placeholder for React splash screen -->
 
     <div id="root"></div>
     
-    <script>
-      // Hide loading screen and start video when animation ends
-      function hideLoadingScreen() {
-        const loadingElement = document.getElementById('loading');
-        if (loadingElement) {
-          loadingElement.classList.add('hidden');
-          window.setTimeout(() => {
-            loadingElement.style.display = 'none';
-          }, 300);
-        }
-      }
-
-      window.hideLoadingScreen = hideLoadingScreen;
-
-      // Universal Links Detection and Handling
+      <script>
+        // Universal Links Detection and Handling
       function detectTelegramWebApp() {
         const urlParams = new URLSearchParams(window.location.search);
         const isTelegramWebApp = window.Telegram && window.Telegram.WebApp;
@@ -237,8 +186,6 @@
         });
       }
 
-      // Loading screen will be hidden automatically when the intro
-      // video finishes playing.
     </script>
     
     <script type="module" src="/src/main.tsx"></script>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,20 +9,6 @@ import { TelegramWebAppProvider } from './components/TelegramWebAppProvider';
 import AuthCallback from './pages/AuthCallback';
 import TelegramLoginRedirect from './components/TelegramLoginRedirect';
 
-// Hide loading screen when React app mounts
-function hideLoadingScreen() {
-  const loadingElement = document.getElementById('loading');
-  if (loadingElement) {
-    loadingElement.classList.add('hidden');
-    window.setTimeout(() => {
-      loadingElement.style.display = 'none';
-    }, 300);
-  }
-}
-
-// Expose helper for React components (StartLoader)
-window.hideLoadingScreen = hideLoadingScreen;
-
 const root = createRoot(document.getElementById('root')!);
 
 root.render(


### PR DESCRIPTION
## Summary
- clean out old loading spinner and hide function
- drop loading helper references in `main.tsx`

## Testing
- `npm test`
- `npm run lint` *(fails: several lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_687d1b96e7648324863a3c7078577b30