### PR TITLE
Fix eslint errors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,7 +64,6 @@ function App() {
   const [selectedChapter, setSelectedChapter] = useState<number | null>(null);
   const [selectedSection, setSelectedSection] = useState<number | null>(null);
   const [sectionResults, setSectionResults] = useState<QuestionResults | null>(null);
-  const [earnedAchievements, setEarnedAchievements] = useState<string[]>([]);
 
   // Test interface state
   const [testView, setTestView] = useState<'intro' | 'test' | 'results'>('intro');
@@ -319,14 +318,13 @@ function App() {
           results.totalQuestions,
           timeSpent
         );
-        const { achievements } = await (saveTestResults(
+        await saveTestResults(
           selectedChapter,
           selectedSection,
           results.correctAnswers,
           results.totalQuestions,
           timeSpent
-        ) as any);
-        setEarnedAchievements(achievements);
+        );
         await refreshStats();
       } catch (err) {
         console.error('Ошибка сохранения результатов раздела:', err);

--- a/src/components/MyAccount.tsx
+++ b/src/components/MyAccount.tsx
@@ -1,6 +1,6 @@
 import { FC, useState, useRef, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { User, Shield, LogOut, Pencil, Check, X } from 'lucide-react'
+import { User, Shield, LogOut, Check } from 'lucide-react'
 import { useAuth } from './SupabaseAuthProvider'
 import { isAdmin } from '../utils/adminUtils.js'
 import { findOrCreateUserProfile } from '../services/authService.js'
@@ -30,7 +30,6 @@ const MyAccount: FC<MyAccountProps> = ({ onBackToHome, onStartChapter }) => {
     signOut,
     isAuthenticated,
     updateProfile,
-    refreshStats
   } = useAuth() as any
 
   const navigate = useNavigate()
@@ -108,7 +107,6 @@ const MyAccount: FC<MyAccountProps> = ({ onBackToHome, onStartChapter }) => {
   }
 
   const telegramUser = window.Telegram?.WebApp?.initDataUnsafe?.user
-  const isTelegramUser = Boolean(telegramUser)
 
   useEffect(() => {
     if (!isAuthenticated && telegramUser) {

--- a/src/components/QuestionInterface.tsx
+++ b/src/components/QuestionInterface.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, type FC } from 'react';
+import { useState, type FC } from 'react';
 import { HelpCircle, Eye, ArrowRight, X, Book } from 'lucide-react';
 import LoadingScreen from './LoadingScreen';
 import { fetchTheoryBlocks, fetchQuestions } from '../services/courseService.js'
@@ -48,7 +48,7 @@ const QuestionInterface: FC<QuestionInterfaceProps> = ({
   const [currentTheoryBlock, setCurrentTheoryBlock] = useState(0);
   const [theoryBlocks, setTheoryBlocks] = useState<Array<{ id: number; title: string; content: string; examples: string[]; key_terms: string[] }>>([])
   const [questions, setQuestions] = useState<Array<{ id: number; type: string; question: string; options: string[]; correctAnswer: string; explanation: string; hints: string[]; difficulty: string }>>([])
-  const { loading, error, data } = useLoadData(async () => {
+  const { loading, error } = useLoadData(async () => {
     const theory = await fetchTheoryBlocks(sectionId)
     const qData = await fetchQuestions(sectionId)
         console.log('Loaded questions count:', qData.length)

--- a/src/components/SectionComplete.tsx
+++ b/src/components/SectionComplete.tsx
@@ -31,7 +31,6 @@ const SectionComplete: FC<SectionCompleteProps> = ({
 }) => {
   const { refreshStats } = useAuth();
   const percentage = Math.round((results.correctAnswers / results.totalQuestions) * 100);
-  const incorrectCount = results.incorrectAnswers.length;
   const accuracy = results.totalQuestions > 0 ? results.correctAnswers / results.totalQuestions : 0;
 
   const [nextSectionId, setNextSectionId] = useState<string | undefined>(undefined);

--- a/src/components/SectionFailed.tsx
+++ b/src/components/SectionFailed.tsx
@@ -7,7 +7,7 @@ interface SectionFailedProps {
   onRetry?: () => void;
 }
 
-const SectionFailed = ({ sectionId, delay = 2000, onRetry }: SectionFailedProps) => {
+const SectionFailed = ({ delay = 2000, onRetry }: SectionFailedProps) => {
   const [showRetry, setShowRetry] = useState(false);
   const [dots, setDots] = useState('');
 

--- a/src/components/SectionSuccess.tsx
+++ b/src/components/SectionSuccess.tsx
@@ -10,7 +10,6 @@ interface SectionSuccessProps {
 }
 
 const SectionSuccess = ({
-  sectionId,
   nextSectionId,
   nextChapterId,
   delay = 2000,


### PR DESCRIPTION
## Summary
- drop unused earnedAchievements state
- tidy MyAccount imports and remove unused vars
- remove unused useEffect import in QuestionInterface
- drop unused incorrect count from SectionComplete
- ignore unused section id props in SectionFailed and SectionSuccess

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687d276a842883249bc8b4edb0efc8b2