### PR TITLE
Add debug logs for saveProgress

### DIFF
--- a/src/components/MyAccount.tsx
+++ b/src/components/MyAccount.tsx
@@ -53,6 +53,11 @@ const MyAccount: FC<MyAccountProps> = ({ onBackToHome, onStartChapter }) => {
     progressData
   } = useUserProgress(userId)
 
+  // Debug info from localStorage about saveProgress
+  const debugCall = localStorage.getItem('saveProgress_called')
+  const debugStatus = localStorage.getItem('saveProgress_success')
+  const debugError = localStorage.getItem('saveProgress_error')
+
   useEffect(() => {
     setNewUsername(profile?.username || '')
   }, [profile])
@@ -193,6 +198,12 @@ const MyAccount: FC<MyAccountProps> = ({ onBackToHome, onStartChapter }) => {
       </div>
       <div className="p-6">
         <SummaryCards stats={stats} startDate={startDate} />
+        {/* Debug info to check saveProgress() calls */}
+        <div className="text-sm text-emerald-700 mb-4">
+          <p>⏱️ Save Progress: {debugCall || 'не вызывался'}</p>
+          <p>✅ Статус: {debugStatus || 'нет данных'}</p>
+          <p>❌ Ошибка: {debugError || 'ошибок нет'}</p>
+        </div>
         {progressLoading ? (
           <div className="rounded-2xl p-4 bg-white shadow my-4" />
         ) : (

--- a/src/services/progressService.js
+++ b/src/services/progressService.js
@@ -22,6 +22,9 @@ export async function saveProgress(
   hintsUsed = 0
 ) {
   try {
+    // Отмечаем вызов функции в localStorage для отладки
+    localStorage.setItem('saveProgress_called', new Date().toISOString())
+
     const user = await getCurrentUser()
     if (!user) {
       console.warn('User not authenticated, skipping save')
@@ -54,12 +57,19 @@ export async function saveProgress(
       .select()
       .single()
 
-    if (error) throw error
+    if (error) {
+      localStorage.setItem('saveProgress_error', error.message)
+      throw error
+    }
 
+    // Отмечаем успешное сохранение
+    localStorage.setItem('saveProgress_success', 'ok')
     console.log('✅ Ответ сохранен успешно')
     return data
   } catch (error) {
     console.error('❌ Ошибка сохранения ответа:', error.message)
+    // Сохраняем текст ошибки для отладки
+    localStorage.setItem('saveProgress_error', error.message)
     throw new Error(`Ошибка сохранения ответа: ${error.message}`)
   }
 }


### PR DESCRIPTION
## Summary
- add localStorage markers in `saveProgress` for troubleshooting
- surface debug info in `MyAccount` to display save status

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d52501d5c8324b2405e9927dc584d