### PR TITLE
Display progress summary cards

### DIFF
--- a/src/components/MyAccount.tsx
+++ b/src/components/MyAccount.tsx
@@ -13,7 +13,6 @@ import SectionProgressList from './account/SectionProgressList'
 import SummaryCards from './account/SummaryCards'
 import useChapterStats from '../hooks/useChapterStats'
 import useUserProgress from '../hooks/useUserProgress'
-import { formatHoursMinutes } from '../utils/formatTime'
 
 interface MyAccountProps {
   onBackToHome: () => void
@@ -43,7 +42,6 @@ const MyAccount: FC<MyAccountProps> = ({ onBackToHome, onStartChapter }) => {
 
   const chapterStats = useChapterStats(userId)
   const {
-    progressLoading,
     startDate,
     completedChapters,
     totalStudyMinutes,
@@ -129,6 +127,12 @@ const MyAccount: FC<MyAccountProps> = ({ onBackToHome, onStartChapter }) => {
 
   const hasAdminAccess = () => isAdmin(profile?.username, user?.email)
 
+  // Метрики прогресса
+  const totalChapters = chapterStats?.totalChapters || chapterProgress.length
+  const completedChaptersCount = chapterStats?.completedChapters ?? completedChapters
+  const totalSections = chapterProgress.reduce((sum, cp) => sum + cp.totalSections, 0)
+  const completedSections = chapterProgress.reduce((sum, cp) => sum + cp.completedSections, 0)
+
   if (loading) {
     return <LoadingScreen />
   }
@@ -197,28 +201,22 @@ const MyAccount: FC<MyAccountProps> = ({ onBackToHome, onStartChapter }) => {
         </div>
       </div>
       <div className="p-6">
-        <SummaryCards stats={stats} startDate={startDate} />
+        <SummaryCards
+          completedChapters={completedChaptersCount}
+          totalChapters={totalChapters}
+          completedSections={completedSections}
+          totalSections={totalSections}
+          totalTimeMinutes={totalStudyMinutes}
+          averageAccuracy={averageAccuracy}
+          startDate={startDate}
+        />
         {/* Debug info to check saveProgress() calls */}
         <div className="text-sm text-emerald-700 mb-4">
           <p>⏱️ Save Progress: {debugCall || 'не вызывался'}</p>
           <p>✅ Статус: {debugStatus || 'нет данных'}</p>
           <p>❌ Ошибка: {debugError || 'ошибок нет'}</p>
         </div>
-        {progressLoading ? (
-          <div className="rounded-2xl p-4 bg-white shadow my-4" />
-        ) : (
-          <div className="rounded-2xl p-4 bg-white shadow my-4 space-y-2">
-            <div className="flex items-center space-x-2">
-              <span className="text-emerald-600">Глав завершено: {completedChapters}</span>
-            </div>
-            <div className="flex items-center space-x-2">
-              <span className="text-emerald-600">Обучение: {formatHoursMinutes(totalStudyMinutes)}</span>
-            </div>
-            <div className="flex items-center space-x-2">
-              <span className="text-emerald-600">Точность ответов: {averageAccuracy}%</span>
-            </div>
-          </div>
-        )}
+
         {achievements && achievements.length > 0 && (
           <div className="bg-white rounded-xl shadow-sm border border-yellow-200 p-6 mb-6">
             <h2 className="text-xl font-semibold text-yellow-800 mb-4 flex items-center">

--- a/src/components/account/SummaryCards.tsx
+++ b/src/components/account/SummaryCards.tsx
@@ -1,39 +1,71 @@
 import { FC } from 'react'
-import { BookOpen, Clock, Trophy } from 'lucide-react'
-import ProgressCard from '../ui/ProgressCard'
-import { formatMinutes } from '../../utils/formatTime'
+import { BookOpen, CheckCircle, Clock, Target, Calendar } from 'lucide-react'
+import Card from '../ui/Card'
+import { formatHoursMinutes } from '../../utils/formatTime'
 
 interface SummaryCardsProps {
-  stats?: {
-    completedChapters: number
-    totalTimeSpent: number
-    accuracy: number
-  }
+  completedChapters: number
+  totalChapters: number
+  completedSections: number
+  totalSections: number
+  totalTimeMinutes: number
+  averageAccuracy: number
   startDate: string | null
 }
 
-const SummaryCards: FC<SummaryCardsProps> = ({ stats, startDate }) => (
-  <div className="grid grid-cols-1 md:grid-cols-4 gap-6 mb-8">
-    <ProgressCard
-      icon={<BookOpen className="w-6 h-6 text-emerald-600" />}
-      value={stats?.completedChapters || 0}
-      label="Глав завершено"
-    />
-    <ProgressCard
-      icon={<Clock className="w-6 h-6 text-green-600" />}
-      value={formatMinutes(Math.round(stats?.totalTimeSpent || 0))}
-      label="Время изучения"
-    />
-    <ProgressCard
-      icon={<Trophy className="w-6 h-6 text-yellow-600" />}
-      value={`${stats?.accuracy || 0}%`}
-      label="Точность ответов"
-    />
-    <ProgressCard
-      icon={<Clock className="w-6 h-6 text-blue-600" />}
-      value={startDate ? new Date(startDate).toLocaleDateString('ru-RU') : '-'}
-      label="Дата начала"
-    />
+const SummaryCards: FC<SummaryCardsProps> = ({
+  completedChapters,
+  totalChapters,
+  completedSections,
+  totalSections,
+  totalTimeMinutes,
+  averageAccuracy,
+  startDate
+}) => (
+  <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mb-6">
+    <Card className="p-4">
+      <div className="flex items-center gap-2">
+        <BookOpen className="w-6 h-6" />
+        <span className="font-medium">Пройдено глав</span>
+      </div>
+      <div className="text-2xl font-bold mt-2">
+        {completedChapters} / {totalChapters}
+      </div>
+    </Card>
+    <Card className="p-4">
+      <div className="flex items-center gap-2">
+        <CheckCircle className="w-6 h-6" />
+        <span className="font-medium">Пройдено разделов</span>
+      </div>
+      <div className="text-2xl font-bold mt-2">
+        {completedSections} / {totalSections}
+      </div>
+    </Card>
+    <Card className="p-4">
+      <div className="flex items-center gap-2">
+        <Clock className="w-6 h-6" />
+        <span className="font-medium">Общее время</span>
+      </div>
+      <div className="text-2xl font-bold mt-2">
+        {formatHoursMinutes(totalTimeMinutes)}
+      </div>
+    </Card>
+    <Card className="p-4">
+      <div className="flex items-center gap-2">
+        <Target className="w-6 h-6" />
+        <span className="font-medium">Средняя точность</span>
+      </div>
+      <div className="text-2xl font-bold mt-2">{averageAccuracy}%</div>
+    </Card>
+    <Card className="p-4">
+      <div className="flex items-center gap-2">
+        <Calendar className="w-6 h-6" />
+        <span className="font-medium">Дата начала</span>
+      </div>
+      <div className="text-2xl font-bold mt-2">
+        {startDate ? new Date(startDate).toLocaleDateString('ru-RU') : '-'}
+      </div>
+    </Card>
   </div>
 )
 

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -1,0 +1,15 @@
+import { FC, ReactNode } from 'react'
+import clsx from 'clsx'
+
+interface CardProps {
+  children: ReactNode
+  className?: string
+}
+
+const Card: FC<CardProps> = ({ children, className }) => (
+  <div className={clsx('rounded-2xl bg-white border shadow-sm', className)}>
+    {children}
+  </div>
+)
+
+export default Card


### PR DESCRIPTION
## Summary
- add a small Card component
- display course metrics in `SummaryCards`
- compute and show user stats in `MyAccount`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687d59f10c308324a3659484b0487fbc