### PR TITLE
Add debug logs for progress loading

### DIFF
--- a/src/components/MyAccount.tsx
+++ b/src/components/MyAccount.tsx
@@ -23,7 +23,6 @@ const MyAccount: FC<MyAccountProps> = ({ onBackToHome, onStartChapter }) => {
   const {
     user,
     profile,
-    stats,
     achievements,
     loading,
     signOut,
@@ -38,9 +37,22 @@ const MyAccount: FC<MyAccountProps> = ({ onBackToHome, onStartChapter }) => {
   const [loginLoading, setLoginLoading] = useState(false)
   const [loginError, setLoginError] = useState<string | null>(null)
 
-  const userId = user?.id || localStorage.getItem('user_id')
+  const [resolvedUserId, setResolvedUserId] = useState<string | null>(null)
 
-  const chapterStats = useChapterStats(userId)
+  useEffect(() => {
+    const resolveUserId = async () => {
+      let id: string | null = user?.id || localStorage.getItem('user_id')
+      if (id && /^\d+$/.test(String(id))) {
+        const tgUsername = window.Telegram?.WebApp?.initDataUnsafe?.user?.username || null
+        id = await findOrCreateUserProfile(String(id), tgUsername)
+      }
+      setResolvedUserId(id)
+      console.log('🆔 ID в MyAccount:', id)
+    }
+    resolveUserId()
+  }, [user])
+
+  const chapterStats = useChapterStats(resolvedUserId)
   const {
     startDate,
     completedChapters,
@@ -49,7 +61,7 @@ const MyAccount: FC<MyAccountProps> = ({ onBackToHome, onStartChapter }) => {
     chapterProgress,
     recommendedChapter,
     progressData
-  } = useUserProgress(userId)
+  } = useUserProgress(resolvedUserId)
 
   // Debug info from localStorage about saveProgress
   const debugCall = localStorage.getItem('saveProgress_called')

--- a/src/hooks/useUserProgress.ts
+++ b/src/hooks/useUserProgress.ts
@@ -46,10 +46,21 @@ export const useUserProgress = (userId?: string | null) => {
         return
       }
 
+      console.log('📊 Запрос расчета прогресса для', userId)
       const { data: progress, error } = await supabase
         .from('user_progress')
         .select('chapter_id, section_id, is_correct, time_spent, answered_at')
         .eq('user_id', userId)
+
+      if (error) {
+        console.log('❌ Ошибка загрузки прогресса:', error)
+      }
+      if (progress) {
+        console.log('📥 Получены данные для расчета:', progress)
+        if (progress.length === 0) {
+          console.log('❗ Прогресс не найден')
+        }
+      }
 
       if (error || !progress) {
         if (error) console.error('Ошибка загрузки прогресса:', error)
@@ -130,11 +141,21 @@ export const useUserProgress = (userId?: string | null) => {
   useEffect(() => {
     const fetchProgress = async () => {
       if (!userId) return
+      console.log('🔄 Запрос прогресса для userId:', userId)
       const { data, error } = await supabase
         .from('user_progress')
         .select('*')
         .eq('user_id', userId)
-      if (!error && data) setProgressData(data as any[])
+      if (error) {
+        console.log('❌ Ошибка загрузки прогресса:', error)
+      }
+      if (data) {
+        console.log('📥 Результат user_progress:', data)
+        if (data.length === 0) {
+          console.log('❗ Прогресс не найден')
+        }
+        setProgressData(data as any[])
+      }
     }
     fetchProgress()
   }, [userId])


### PR DESCRIPTION
## Summary
- resolve user ID via `findOrCreateUserProfile` in MyAccount
- log resolved user ID in MyAccount
- log Supabase user_progress queries in `useUserProgress`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687d5f38a6208324b300379cff26ab71