### PR TITLE
Fix progress queries with UUID

### DIFF
--- a/src/components/MyAccount.tsx
+++ b/src/components/MyAccount.tsx
@@ -115,8 +115,8 @@ const MyAccount: FC<MyAccountProps> = ({ onBackToHome, onStartChapter }) => {
       return
     }
 
-    // ✅ сохраняем telegram_id
-    localStorage.setItem('user_id', tgUser.id.toString())
+    // ✅ сохраняем uuid пользователя
+    localStorage.setItem('user_id', userId)
 
     navigate('/')
   }

--- a/src/components/TelegramLoginRedirect.tsx
+++ b/src/components/TelegramLoginRedirect.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { supabase } from '../services/supabaseClient.js';
 import { useAuth } from './SupabaseAuthProvider';
+import { findOrCreateUserProfile } from '../services/authService.js';
 import LoadingScreen from './LoadingScreen';
 
 const TelegramLoginRedirect = () => {
@@ -22,16 +22,8 @@ const TelegramLoginRedirect = () => {
 
     const initProfile = async () => {
       try {
-        const { error } = await supabase.rpc('create_user_from_telegram', {
-          uid: userId,
-          username: firstName,
-          email: `${userId}@telegram`,
-          telegram_id: userId,
-        });
-
-        if (error) throw error;
-
-        localStorage.setItem('user_id', userId);
+        const uuid = await findOrCreateUserProfile(userId, telegramUser.username || firstName);
+        localStorage.setItem('user_id', uuid);
         setLoading(false);
       } catch (err) {
         console.error('Ошибка входа:', err);

--- a/src/hooks/useUserProfile.ts
+++ b/src/hooks/useUserProfile.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useAuth } from '../components/SupabaseAuthProvider'
-import { getUserProfile } from '../services/authService.js'
+import { getUserProfile, findOrCreateUserProfile } from '../services/authService.js'
 
 export interface UserProfile {
   id: string
@@ -9,11 +9,31 @@ export interface UserProfile {
 
 const useUserProfile = (userId?: string | null) => {
   const { user, profile: authProfile, updateProfile } = useAuth() as any
-  const resolvedId = userId || user?.id || localStorage.getItem('user_id') || null
+  const [resolvedId, setResolvedId] = useState<string | null>(
+    userId || user?.id || localStorage.getItem('user_id') || null
+  )
   const [profile, setProfile] = useState<UserProfile | null>(
     authProfile && (!userId || authProfile?.id === resolvedId) ? authProfile : null
   )
   const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    const resolve = async () => {
+      const id = userId || user?.id || localStorage.getItem('user_id')
+      if (!id) {
+        setResolvedId(null)
+        return
+      }
+      if (/^\d+$/.test(String(id))) {
+        const username = window.Telegram?.WebApp?.initDataUnsafe?.user?.username || null
+        const uuid = await findOrCreateUserProfile(String(id), username)
+        setResolvedId(uuid)
+      } else {
+        setResolvedId(id)
+      }
+    }
+    void resolve()
+  }, [userId, user])
 
   useEffect(() => {
     const load = async () => {


### PR DESCRIPTION
## Summary
- resolve numeric Telegram IDs to UUID before querying user progress
- use UUID in ChapterStats and UserProfile hooks
- update login flow to store UUID in localStorage
- adjust Telegram login redirect to create or fetch profile via RPC

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d604fa1388324bfcd72b7cd4a9bb9