### PR TITLE
Implement bottom navigation animations

### DIFF
--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -1,32 +1,41 @@
 import { Home, FileText, Bot, User } from 'lucide-react';
 import { NavLink } from 'react-router-dom';
+import { motion } from 'framer-motion';
 import clsx from 'clsx';
 
 const navItems = [
-  { label: 'Главная', icon: Home, path: '/' },
-  { label: 'Тест', icon: FileText, path: '/test' },
-  { label: 'AI', icon: Bot, path: '/ai' },
-  { label: 'Аккаунт', icon: User, path: '/account' },
+  { label: 'Главная', icon: Home, path: '/', animation: { scale: 1.2 } },
+  { label: 'Тест', icon: FileText, path: '/test', animation: { y: -8 } },
+  { label: 'AI', icon: Bot, path: '/ai', animation: { rotate: 20 } },
+  {
+    label: 'Аккаунт',
+    icon: User,
+    path: '/account',
+    animation: { boxShadow: '0 0 8px rgb(34 197 94)', backgroundColor: 'rgba(34,197,94,0.2)', borderRadius: '0.375rem' },
+  },
 ];
 
 const BottomNavigation = () => {
   return (
     <nav className="fixed bottom-0 w-full bg-white border-t border-gray-200 flex justify-around py-2 z-50">
-      {navItems.map(({ label, icon: Icon, path }) => (
+      {navItems.map(({ label, icon: Icon, path, animation }) => (
         <NavLink
           key={path}
           to={path}
+          end
           className={({ isActive }) =>
             clsx(
-              'flex flex-col items-center justify-center text-xs transition duration-300 ease-in-out',
+              'flex-1 flex flex-col items-center justify-center text-xs transition-colors duration-300 ease-in-out',
               isActive
                 ? 'text-green-600 font-semibold'
                 : 'text-gray-500 hover:text-green-600'
             )
           }
         >
-          <Icon className="w-5 h-5 mb-1" />
-          <span>{label}</span>
+          <motion.div whileTap={animation} transition={{ duration: 0.2 }} className="flex flex-col items-center justify-center">
+            <Icon className="w-5 h-5 mb-1" />
+            <span>{label}</span>
+          </motion.div>
         </NavLink>
       ))}
     </nav>


### PR DESCRIPTION
## Summary
- animate bottom navigation icons with framer-motion
- make active state more visible and match the URL exactly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d6cc5411483249587188358b78537