### PR TITLE
Add detailed progress stats to account page

### DIFF
--- a/src/components/account/ProgressSummary.tsx
+++ b/src/components/account/ProgressSummary.tsx
@@ -1,0 +1,27 @@
+import { FC } from 'react'
+
+interface ProgressSummaryProps {
+  correct: number
+  incorrect: number
+  totalTime: number
+  completedSections: number
+}
+
+const ProgressSummary: FC<ProgressSummaryProps> = ({
+  correct,
+  incorrect,
+  totalTime,
+  completedSections
+}) => (
+  <div className="bg-white rounded-xl shadow-sm border border-emerald-200 p-6 mb-6">
+    <h2 className="text-xl font-semibold text-emerald-900 mb-4">Общая статистика</h2>
+    <ul className="space-y-1 text-sm text-emerald-700">
+      <li>Правильных ответов: {correct}</li>
+      <li>Неправильных ответов: {incorrect}</li>
+      <li>Общее время: {Math.round(totalTime / 60)} мин</li>
+      <li>Завершено разделов: {completedSections}</li>
+    </ul>
+  </div>
+)
+
+export default ProgressSummary

--- a/src/services/progressService.js
+++ b/src/services/progressService.js
@@ -110,6 +110,33 @@ export async function getUserProgress() {
   }
 }
 
+// Получить подробный прогресс пользователя по разделам и главам
+export async function getFullUserProgress(userId) {
+  try {
+    const { data, error } = await supabase
+      .from('user_progress')
+      .select(`
+        chapter_id,
+        section_id,
+        is_correct,
+        time_spent,
+        answered_at,
+        hints_used
+      `)
+      .eq('user_id', userId)
+
+    if (error) {
+      console.error('Ошибка получения прогресса:', error.message)
+      return []
+    }
+
+    return data
+  } catch (e) {
+    console.error('Критическая ошибка запроса прогресса:', e.message)
+    return []
+  }
+}
+
 /**
  * Получить прогресс по конкретной главе
  * @param {number} chapterId - ID главы


### PR DESCRIPTION
## Summary
- expose `getFullUserProgress` in `progressService`
- fetch detailed progress in `MyAccount` and compute summary
- add `ProgressSummary` component to show totals

## Testing
- `npm run lint` *(fails: `npm` not found)*
- `npm test` *(not run due to missing Node)*

------
https://chatgpt.com/codex/tasks/task_e_687d736e9bb8832482167916ef3cb2ec