### PR TITLE
Refactor learning page state management

### DIFF
--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -2,6 +2,7 @@ import { Home, FileText, Bot, User } from 'lucide-react';
 import { NavLink } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import clsx from 'clsx';
+import { BOTTOM_NAV_ITEM_BASE } from '../utils/classNames';
 
 const navItems = [
   { label: 'Главная', icon: Home, path: '/', animation: { scale: 1.2 } },
@@ -25,7 +26,7 @@ const BottomNavigation = () => {
           end
           className={({ isActive }) =>
             clsx(
-              'flex-1 flex flex-col items-center justify-center text-xs transition-colors duration-300 ease-in-out',
+              BOTTOM_NAV_ITEM_BASE,
               isActive
                 ? 'text-green-600 font-semibold'
                 : 'text-gray-500 hover:text-green-600'

--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -2,6 +2,7 @@ import { FC } from 'react';
 import { NavLink } from 'react-router-dom';
 import { LucideIcon } from 'lucide-react';
 import clsx from 'clsx';
+import { NAV_ITEM_BASE, NAV_ICON_BASE } from '../utils/classNames';
 
 export interface NavigationItem {
   id: string;
@@ -28,19 +29,14 @@ const NavigationBar: FC<NavigationBarProps> = ({ items, show = true }) => {
               end
               className={({ isActive }) =>
                 clsx(
-                  'flex flex-col items-center justify-center flex-1 py-2 px-2 transition-all duration-200 transform min-h-[60px] relative',
+                  NAV_ITEM_BASE,
                   isActive
                     ? 'text-transparent bg-clip-text bg-gradient-to-r from-green-500 to-emerald-400 animate-gradient scale-105'
                     : 'text-gray-500 hover:text-emerald-500 active:scale-95'
                 )
               }
             >
-              <Icon
-                className={clsx(
-                  'w-6 h-6 mb-1 transition-all duration-200',
-                  'text-gray-500'
-                )}
-              />
+              <Icon className={clsx(NAV_ICON_BASE, 'text-gray-500')} />
               <span className="text-xs font-medium transition-all duration-200 text-center leading-tight">
                 {label}
               </span>

--- a/src/hooks/useLearningNavigation.ts
+++ b/src/hooks/useLearningNavigation.ts
@@ -1,0 +1,164 @@
+import { useState } from 'react'
+import { useAuth } from '../components/SupabaseAuthProvider'
+import { findOrCreateUserProfile } from '../services/authService'
+import { supabase } from '../services/supabaseClient'
+import { saveTestResults } from '../services/progressService'
+import type { QuestionResults } from '../components/QuestionInterface'
+
+export type LearningView =
+  | 'chapters'
+  | 'sections'
+  | 'questions'
+  | 'section-complete'
+  | 'chapter-complete'
+
+export function useLearningNavigation() {
+  const [currentView, setCurrentView] = useState<LearningView>('chapters')
+  const [selectedChapter, setSelectedChapter] = useState<number | null>(null)
+  const [selectedSection, setSelectedSection] = useState<number | null>(null)
+  const [sectionResults, setSectionResults] = useState<QuestionResults | null>(null)
+  const [sectionStartTime, setSectionStartTime] = useState<number | null>(null)
+
+  const { profile, refreshStats } = useAuth()
+
+  const saveProgressToSupabase = async (
+    chapterId: number,
+    sectionId: number,
+    correctAnswers: number,
+    totalQuestions: number,
+    timeSpent: number
+  ) => {
+    let userId: string | null | number | undefined =
+      localStorage.getItem('user_id') || (profile as any)?.id
+    if (userId && /^\d+$/.test(String(userId))) {
+      const telegramId = String(userId)
+      const newId = await findOrCreateUserProfile(
+        telegramId,
+        window.Telegram?.WebApp?.initDataUnsafe?.user?.username || null
+      )
+      if (!newId) {
+        console.error('Не удалось создать профиль через RPC')
+        return
+      }
+      userId = newId
+    }
+    if (!userId || /^\d+$/.test(String(userId))) {
+      return
+    }
+
+    const accuracy = Math.round((correctAnswers / totalQuestions) * 100)
+    const completed = accuracy >= 70
+
+    const upsertData = {
+      user_id: userId,
+      chapter_id: chapterId,
+      section_id: sectionId,
+      completed,
+      accuracy,
+      time_spent: timeSpent
+    }
+
+    const { error } = await supabase
+      .from('user_progress')
+      .upsert(upsertData, { onConflict: 'user_id, section_id' })
+
+    if (error) {
+      console.error('Ошибка при сохранении прогресса:', error.message)
+    }
+  }
+
+  const handleChapterSelect = (chapterId: number) => {
+    setSelectedChapter(chapterId)
+    setCurrentView('sections')
+  }
+
+  const handleSectionSelect = (sectionId: number) => {
+    setSelectedSection(sectionId)
+    setSectionStartTime(Date.now())
+    setCurrentView('questions')
+  }
+
+  const handleQuestionComplete = async (results: QuestionResults) => {
+    setSectionResults(results)
+    if (selectedChapter && selectedSection) {
+      try {
+        const timeSpent = sectionStartTime ? Math.round((Date.now() - sectionStartTime) / 1000) : 0
+        await saveProgressToSupabase(
+          selectedChapter,
+          selectedSection,
+          results.correctAnswers,
+          results.totalQuestions,
+          timeSpent
+        )
+        await saveTestResults(
+          selectedChapter,
+          selectedSection,
+          results.correctAnswers,
+          results.totalQuestions,
+          timeSpent
+        )
+        await refreshStats()
+      } catch (err) {
+        console.error('Ошибка сохранения результатов раздела:', err)
+      }
+    }
+    setSectionStartTime(null)
+    setCurrentView('section-complete')
+  }
+
+  const handleNextChapter = () => {
+    if (selectedChapter) {
+      setSelectedChapter(selectedChapter + 1)
+      setCurrentView('sections')
+    }
+  }
+
+  const handleBackToChapters = () => {
+    setCurrentView('chapters')
+    setSelectedChapter(null)
+    setSelectedSection(null)
+    setSectionResults(null)
+  }
+
+  const handleBackToSections = () => {
+    setCurrentView('sections')
+    setSelectedSection(null)
+  }
+
+  const handleRetrySection = () => {
+    setSectionResults(null)
+    setSectionStartTime(Date.now())
+    setCurrentView('questions')
+  }
+
+  const handleNextStep = (nextSectionId?: string, nextChapterId?: string) => {
+    setSectionResults(null)
+    setSectionStartTime(null)
+    if (nextSectionId) {
+      setSelectedSection(parseInt(nextSectionId))
+      setCurrentView('questions')
+    } else if (nextChapterId) {
+      setSelectedChapter(parseInt(nextChapterId))
+      setSelectedSection(null)
+      setCurrentView('sections')
+    } else {
+      setCurrentView('chapters')
+    }
+  }
+
+  return {
+    currentView,
+    selectedChapter,
+    selectedSection,
+    sectionResults,
+    profile,
+    handleChapterSelect,
+    handleSectionSelect,
+    handleQuestionComplete,
+    handleNextChapter,
+    handleBackToChapters,
+    handleBackToSections,
+    handleRetrySection,
+    handleNextStep
+  }
+}

--- a/src/pages/LearningPage.tsx
+++ b/src/pages/LearningPage.tsx
@@ -1,149 +1,26 @@
-import { useState } from 'react';
 import ChaptersList from '../components/ChaptersList';
 import SectionsList from '../components/SectionsList';
-import QuestionInterface, { type QuestionResults } from '../components/QuestionInterface';
+import QuestionInterface from '../components/QuestionInterface';
 import SectionComplete from '../components/SectionComplete';
 import ChapterComplete from '../components/ChapterComplete';
-import { useAuth } from '../components/SupabaseAuthProvider';
-import { saveTestResults } from '../services/progressService';
-import { supabase } from '../services/supabaseClient';
-import { findOrCreateUserProfile } from '../services/authService';
+import { useLearningNavigation } from '../hooks/useLearningNavigation';
 
 const LearningPage = () => {
-  const [currentView, setCurrentView] = useState<'chapters' | 'sections' | 'questions' | 'section-complete' | 'chapter-complete'>('chapters');
-  const [selectedChapter, setSelectedChapter] = useState<number | null>(null);
-  const [selectedSection, setSelectedSection] = useState<number | null>(null);
-  const [sectionResults, setSectionResults] = useState<QuestionResults | null>(null);
-  const [sectionStartTime, setSectionStartTime] = useState<number | null>(null);
-
-  const { profile, refreshStats } = useAuth();
-
-  const saveProgressToSupabase = async (
-    chapterId: number,
-    sectionId: number,
-    correctAnswers: number,
-    totalQuestions: number,
-    timeSpent: number
-  ) => {
-    let userId = localStorage.getItem('user_id') || (profile as any)?.id;
-    if (userId && /^\d+$/.test(String(userId))) {
-      const telegramId = String(userId);
-      const newId = await findOrCreateUserProfile(
-        telegramId,
-        window.Telegram?.WebApp?.initDataUnsafe?.user?.username || null
-      );
-      if (!newId) {
-        console.error('Не удалось создать профиль через RPC');
-        return;
-      }
-      userId = newId;
-    }
-    if (!userId || /^\d+$/.test(String(userId))) {
-      return;
-    }
-
-    const accuracy = Math.round((correctAnswers / totalQuestions) * 100);
-    const completed = accuracy >= 70;
-
-    const upsertData = {
-      user_id: userId,
-      chapter_id: chapterId,
-      section_id: sectionId,
-      completed,
-      accuracy,
-      time_spent: timeSpent
-    };
-
-    const { error } = await supabase
-      .from('user_progress')
-      .upsert(upsertData, { onConflict: 'user_id, section_id' });
-
-    if (error) {
-      console.error('Ошибка при сохранении прогресса:', error.message);
-    }
-  };
-
-  const handleChapterSelect = (chapterId: number) => {
-    setSelectedChapter(chapterId);
-    setCurrentView('sections');
-  };
-
-  const handleSectionSelect = (sectionId: number) => {
-    setSelectedSection(sectionId);
-    setSectionStartTime(Date.now());
-    setCurrentView('questions');
-  };
-
-  const handleQuestionComplete = async (results: QuestionResults) => {
-    setSectionResults(results);
-    if (selectedChapter && selectedSection) {
-      try {
-        const timeSpent = sectionStartTime ? Math.round((Date.now() - sectionStartTime) / 1000) : 0;
-        await saveProgressToSupabase(
-          selectedChapter,
-          selectedSection,
-          results.correctAnswers,
-          results.totalQuestions,
-          timeSpent
-        );
-        await saveTestResults(
-          selectedChapter,
-          selectedSection,
-          results.correctAnswers,
-          results.totalQuestions,
-          timeSpent
-        );
-        await refreshStats();
-      } catch (err) {
-        console.error('Ошибка сохранения результатов раздела:', err);
-      }
-    }
-    setSectionStartTime(null);
-    setCurrentView('section-complete');
-  };
-
-  const handleNextChapter = () => {
-    if (selectedChapter) {
-      setSelectedChapter(selectedChapter + 1);
-      setCurrentView('sections');
-    }
-  };
-
-  const handleBackToChapters = () => {
-    setCurrentView('chapters');
-    setSelectedChapter(null);
-    setSelectedSection(null);
-    setSectionResults(null);
-  };
-
-  const handleBackToSections = () => {
-    setCurrentView('sections');
-    setSelectedSection(null);
-  };
-
-  const handleRetrySection = () => {
-    setSectionResults(null);
-    setSectionStartTime(Date.now());
-    setCurrentView('questions');
-  };
-
-  const handleNextStep = (
-    nextSectionId?: string,
-    nextChapterId?: string
-  ) => {
-    setSectionResults(null);
-    setSectionStartTime(null);
-    if (nextSectionId) {
-      setSelectedSection(parseInt(nextSectionId));
-      setCurrentView('questions');
-    } else if (nextChapterId) {
-      setSelectedChapter(parseInt(nextChapterId));
-      setSelectedSection(null);
-      setCurrentView('sections');
-    } else {
-      setCurrentView('chapters');
-    }
-  };
+  const {
+    currentView,
+    selectedChapter,
+    selectedSection,
+    sectionResults,
+    profile,
+    handleChapterSelect,
+    handleSectionSelect,
+    handleQuestionComplete,
+    handleNextChapter,
+    handleBackToChapters,
+    handleBackToSections,
+    handleRetrySection,
+    handleNextStep
+  } = useLearningNavigation();
 
   switch (currentView) {
     case 'chapters':

--- a/src/utils/classNames.ts
+++ b/src/utils/classNames.ts
@@ -1,0 +1,3 @@
+export const NAV_ITEM_BASE = 'flex flex-col items-center justify-center flex-1 py-2 px-2 transition-all duration-200 transform min-h-[60px] relative';
+export const NAV_ICON_BASE = 'w-6 h-6 mb-1 transition-all duration-200';
+export const BOTTOM_NAV_ITEM_BASE = 'flex-1 flex flex-col items-center justify-center text-xs transition-colors duration-300 ease-in-out';


### PR DESCRIPTION
## Summary
- add tailwind class constants for navigation items
- reuse constants in navigation components
- create `useLearningNavigation` hook to manage LearningPage state
- simplify `LearningPage` by delegating logic to the hook

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e0bcc78348324bd3dc6cac1c3d98c