### PR TITLE
Remove duplicate method declaration in telegram webapp service

### DIFF
--- a/src/services/telegramWebApp.ts
+++ b/src/services/telegramWebApp.ts
@@ -73,7 +73,6 @@ interface TelegramWebApp {
   sendData(data: string): void;
   openLink(url: string): void;
   openTelegramLink(url: string): void;
-  openTelegramLink(url: string): void;
   showPopup(params: {
     title?: string;
     message: string;


### PR DESCRIPTION
## Summary
- tidy up telegram web app TypeScript interface
- remove duplicate `openTelegramLink` declaration

## Testing
- `npx tsc -b`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_687e1195eba88324b2765b9386feb164