### PR TITLE
Add TypeScript types for auth hook

### DIFF
--- a/src/components/SupabaseAuthProvider.tsx
+++ b/src/components/SupabaseAuthProvider.tsx
@@ -1,18 +1,22 @@
 import { createContext, useContext, type ReactNode } from 'react'
-import useAuthHook from '../hooks/useSupabaseAuth.js'
+import useAuthHook, {
+  type AuthUser,
+  type UserProfile,
+  type UserStats,
+} from '../hooks/useSupabaseAuth'
 
 // Тип для значения контекста аутентификации
 export interface AuthContextValue {
-  user: unknown
-  profile: unknown
-  stats: unknown
-  achievements: unknown[]
+  user: AuthUser | null
+  profile: UserProfile | null
+  stats: UserStats | null
+  achievements: any[]
   loading: boolean
   error: string | null
   isAuthenticated: boolean
   isAdmin: boolean
   signOut: () => Promise<void>
-  updateProfile: (updates: Record<string, unknown>) => Promise<unknown>
+  updateProfile: (updates: Record<string, any>) => Promise<UserProfile | null>
   refreshStats: () => Promise<void>
   clearError: () => void
 }
@@ -26,12 +30,10 @@ const SupabaseAuthContext = createContext<AuthContextValue | null>(null)
  * @param {React.ReactNode} props.children - Дочерние компоненты
  */
 export function SupabaseAuthProvider({ children }: { children: ReactNode }) {
-  const auth = useAuthHook() as unknown as Omit<AuthContextValue, 'isAdmin'> & {
-    profile: { is_admin?: boolean }
-  }
+  const auth = useAuthHook()
 
   const isAdmin = Boolean(auth.profile?.is_admin)
-  const value = { ...auth, isAdmin } as AuthContextValue
+  const value: AuthContextValue = { ...auth, isAdmin }
 
   return (
     <SupabaseAuthContext.Provider value={value}>

--- a/src/features/account/MyAccount.tsx
+++ b/src/features/account/MyAccount.tsx
@@ -30,7 +30,7 @@ const MyAccount: FC<MyAccountProps> = ({ onBackToHome, onStartChapter }) => {
     signOut,
     isAuthenticated,
     updateProfile,
-  } = useAuth() as any
+  } = useAuth()
 
   const navigate = useNavigate()
 

--- a/src/hooks/useLearningNavigation.ts
+++ b/src/hooks/useLearningNavigation.ts
@@ -29,7 +29,7 @@ export function useLearningNavigation() {
     timeSpent: number
   ) => {
     let userId: string | null | number | undefined =
-      localStorage.getItem('user_id') || (profile as any)?.id
+      localStorage.getItem('user_id') || profile?.id
     if (userId && /^\d+$/.test(String(userId))) {
       const telegramId = String(userId)
       const newId = await findOrCreateUserProfile(

--- a/src/hooks/useUserProfile.ts
+++ b/src/hooks/useUserProfile.ts
@@ -8,7 +8,7 @@ export interface UserProfile {
 }
 
 const useUserProfile = (userId?: string | null) => {
-  const { user, profile: authProfile, updateProfile } = useAuth() as any
+  const { user, profile: authProfile, updateProfile } = useAuth()
   const [resolvedId, setResolvedId] = useState<string | null>(
     userId || user?.id || localStorage.getItem('user_id') || null
   )
@@ -47,7 +47,7 @@ const useUserProfile = (userId?: string | null) => {
       }
       setLoading(true)
       const data = await getUserProfile(resolvedId)
-      setProfile(data as any)
+      setProfile(data as UserProfile)
       setLoading(false)
     }
     void load()

--- a/src/pages/AdminPanelPage.tsx
+++ b/src/pages/AdminPanelPage.tsx
@@ -4,7 +4,7 @@ import { useAuth } from '../components/SupabaseAuthProvider';
 
 const AdminPanelPage = () => {
   const navigate = useNavigate();
-  const { profile } = useAuth() as any;
+  const { profile } = useAuth();
   return (
     <AdminPanel
       onClose={() => navigate('/')}

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -5,7 +5,7 @@ import { isAdmin } from '../utils/adminUtils';
 
 const LandingPage = () => {
   const { profile } = useAuth();
-  const isAdminUser = isAdmin((profile as any)?.username, (profile as any)?.email);
+  const isAdminUser = isAdmin(profile?.username, profile?.email as string | undefined);
 
   const isTelegramWebApp = !!window?.Telegram?.WebApp?.initData;
 

--- a/src/pages/LearningPage.tsx
+++ b/src/pages/LearningPage.tsx
@@ -27,7 +27,7 @@ const LearningPage = () => {
       return (
         <ChaptersList
           onChapterSelect={handleChapterSelect}
-          currentUser={(profile as any)?.username}
+          currentUser={profile?.username}
         />
       );
     case 'sections':


### PR DESCRIPTION
## Summary
- rename `useSupabaseAuth.js` to TypeScript and add interfaces
- update SupabaseAuthProvider to use typed hook
- adjust components using the auth hook

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687e12b6cde883249410f18126040af7