### PR TITLE
Fix Telegram login and nav

### DIFF
--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react';
-import { NavLink } from 'react-router-dom';
+import { NavLink, useLocation } from 'react-router-dom';
 import { LucideIcon } from 'lucide-react';
 import clsx from 'clsx';
 import { NAV_ITEM_BASE, NAV_ICON_BASE } from '../utils/classNames';
@@ -17,31 +17,33 @@ interface NavigationBarProps {
 }
 
 const NavigationBar: FC<NavigationBarProps> = ({ items, show = true }) => {
+  const { pathname } = useLocation();
   if (!show) return null;
   return (
     <nav className="fixed bottom-0 left-0 right-0 bg-white border-t border-emerald-200 shadow-lg z-50 safe-area-inset-bottom">
       <div className="max-w-md mx-auto">
         <div className="flex justify-around items-center h-20 px-4 py-2">
-          {items.map(({ id, label, icon: Icon, path }) => (
-            <NavLink
-              key={id}
-              to={path}
-              end
-              className={({ isActive }) =>
-                clsx(
+          {items.map(({ id, label, icon: Icon, path }) => {
+            const active = pathname === path;
+            return (
+              <NavLink
+                key={id}
+                to={path}
+                end
+                className={clsx(
                   NAV_ITEM_BASE,
-                  isActive
+                  active
                     ? 'text-transparent bg-clip-text bg-gradient-to-r from-green-500 to-emerald-400 animate-gradient scale-105'
                     : 'text-gray-500 hover:text-emerald-500 active:scale-95'
-                )
-              }
-            >
+                )}
+              >
               <Icon className={clsx(NAV_ICON_BASE, 'text-gray-500')} />
               <span className="text-xs font-medium transition-all duration-200 text-center leading-tight">
                 {label}
               </span>
-            </NavLink>
-          ))}
+              </NavLink>
+            );
+          })}
         </div>
       </div>
     </nav>

--- a/src/components/SectionComplete.tsx
+++ b/src/components/SectionComplete.tsx
@@ -3,6 +3,7 @@ import type { QuestionResultItem } from './QuestionInterface';
 import { supabase } from '../services/supabaseClient';
 import { findOrCreateUserProfile, getCurrentUser } from '../services/authService';
 import { useAuth } from './SupabaseAuthProvider';
+import { getTelegramUser } from '../utils/telegram';
 import SectionFailed from './SectionFailed';
 import SectionSuccess from './SectionSuccess';
 import { getNextStep } from '../utils/navigation.js';
@@ -51,8 +52,9 @@ const SectionComplete: FC<SectionCompleteProps> = ({
       const current = await getCurrentUser() as any;
       userId = current?.id || null;
 
-      const telegramId = window.Telegram?.WebApp?.initDataUnsafe?.user?.id;
-      const telegramUsername = window.Telegram?.WebApp?.initDataUnsafe?.user?.username || null;
+      const tgUser = getTelegramUser();
+      const telegramId = tgUser?.id;
+      const telegramUsername = tgUser?.username || null;
 
       if (!userId && telegramId) {
         userId = await findOrCreateUserProfile(String(telegramId), telegramUsername);

--- a/src/components/TelegramLoginRedirect.tsx
+++ b/src/components/TelegramLoginRedirect.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from './SupabaseAuthProvider';
 import { findOrCreateUserProfile } from '../services/authService';
+import { getTelegramUser } from '../utils/telegram';
 import LoadingScreen from './LoadingScreen';
 
 const TelegramLoginRedirect = () => {
@@ -12,8 +13,8 @@ const TelegramLoginRedirect = () => {
 
   useEffect(() => {
     window.Telegram?.WebApp?.ready();
-    const telegramUser = window?.Telegram?.WebApp?.initDataUnsafe?.user;
-    if (!telegramUser?.id) {
+    const telegramUser = getTelegramUser();
+    if (!telegramUser) {
       setLoading(false);
       return;
     }
@@ -45,7 +46,7 @@ const TelegramLoginRedirect = () => {
       localStorage.getItem('user_id')
     ) {
       console.log('Navigate to /account', {
-        telegramUser: window?.Telegram?.WebApp?.initDataUnsafe?.user,
+        telegramUser: getTelegramUser(),
         user_id: localStorage.getItem('user_id'),
         profile
       });

--- a/src/features/account/MyAccount.tsx
+++ b/src/features/account/MyAccount.tsx
@@ -15,6 +15,7 @@ import useChapterStats from '../../hooks/useChapterStats'
 import useUserProgress from '../../hooks/useUserProgress'
 import ProgressSummary from './ProgressSummary'
 import { getFullUserProgress } from '../../services/progressService'
+import { getTelegramUser } from '../../utils/telegram'
 
 interface MyAccountProps {
   onBackToHome: () => void
@@ -51,7 +52,8 @@ const MyAccount: FC<MyAccountProps> = ({ onBackToHome, onStartChapter }) => {
     const resolveUserId = async () => {
       let id: string | null = user?.id || localStorage.getItem('user_id')
       if (id && /^\d+$/.test(String(id))) {
-        const tgUsername = window.Telegram?.WebApp?.initDataUnsafe?.user?.username || null
+        const tgUser = getTelegramUser()
+        const tgUsername = tgUser?.username || null
         id = await findOrCreateUserProfile(String(id), tgUsername)
       }
       setResolvedUserId(id)
@@ -129,7 +131,7 @@ const MyAccount: FC<MyAccountProps> = ({ onBackToHome, onStartChapter }) => {
   }
 
   const handleTelegramLogin = async () => {
-    const tgUser = window.Telegram?.WebApp?.initDataUnsafe?.user
+    const tgUser = getTelegramUser()
     if (!tgUser) {
       console.warn('Пользователь Telegram не найден')
       setLoginError('Пользователь Telegram не найден')
@@ -151,7 +153,7 @@ const MyAccount: FC<MyAccountProps> = ({ onBackToHome, onStartChapter }) => {
     navigate('/')
   }
 
-  const telegramUser = window.Telegram?.WebApp?.initDataUnsafe?.user
+  const telegramUser = getTelegramUser()
 
   useEffect(() => {
     if (!isAuthenticated && telegramUser) {

--- a/src/hooks/useChapterStats.ts
+++ b/src/hooks/useChapterStats.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { supabase } from '../services/supabaseClient'
 import { findOrCreateUserProfile } from '../services/authService'
+import { getTelegramUser } from '../utils/telegram'
 
 export interface ChapterStats {
   totalTime: number
@@ -21,7 +22,8 @@ export const useChapterStats = (userId?: string | null) => {
         return
       }
       if (/^\d+$/.test(String(userId))) {
-        const username = window.Telegram?.WebApp?.initDataUnsafe?.user?.username || null
+        const tgUser = getTelegramUser()
+        const username = tgUser?.username || null
         const uuid = await findOrCreateUserProfile(String(userId), username)
         setResolvedId(uuid)
       } else {

--- a/src/hooks/useLearningNavigation.ts
+++ b/src/hooks/useLearningNavigation.ts
@@ -4,6 +4,7 @@ import { findOrCreateUserProfile } from '../services/authService'
 import { supabase } from '../services/supabaseClient'
 import { saveTestResults } from '../services/progressService'
 import type { QuestionResults } from '../components/QuestionInterface'
+import { getTelegramUser } from '../utils/telegram'
 
 export type LearningView =
   | 'chapters'
@@ -34,7 +35,7 @@ export function useLearningNavigation() {
       const telegramId = String(userId)
       const newId = await findOrCreateUserProfile(
         telegramId,
-        window.Telegram?.WebApp?.initDataUnsafe?.user?.username || null
+        getTelegramUser()?.username || null
       )
       if (!newId) {
         console.error('Не удалось создать профиль через RPC')

--- a/src/hooks/useSupabaseAuth.ts
+++ b/src/hooks/useSupabaseAuth.ts
@@ -4,6 +4,7 @@ import {
   signOut as authSignOut,
   findOrCreateUserProfile
 } from '../services/authService'
+import { getTelegramUser } from '../utils/telegram'
 import { supabase } from '../services/supabaseClient'
 import { getUserStats, getUserAchievements } from '../services/progressService'
 
@@ -101,8 +102,8 @@ export function useSupabaseAuth(): UseSupabaseAuthResult {
   // Инициализация при монтировании через Telegram WebApp
   useEffect(() => {
     const init = async () => {
-      const tgUser = window?.Telegram?.WebApp?.initDataUnsafe?.user
-      if (!tgUser?.id) {
+      const tgUser = getTelegramUser()
+      if (!tgUser) {
         setLoading(false)
         return
       }

--- a/src/hooks/useUserProfile.ts
+++ b/src/hooks/useUserProfile.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useAuth } from '../components/SupabaseAuthProvider'
 import { getUserProfile, findOrCreateUserProfile } from '../services/authService'
+import { getTelegramUser } from '../utils/telegram'
 
 export interface UserProfile {
   id: string
@@ -25,7 +26,8 @@ const useUserProfile = (userId?: string | null) => {
         return
       }
       if (/^\d+$/.test(String(id))) {
-        const username = window.Telegram?.WebApp?.initDataUnsafe?.user?.username || null
+        const tgUser = getTelegramUser()
+        const username = tgUser?.username || null
         const uuid = await findOrCreateUserProfile(String(id), username)
         setResolvedId(uuid)
       } else {

--- a/src/hooks/useUserProgress.ts
+++ b/src/hooks/useUserProgress.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { supabase } from '../services/supabaseClient'
 import { findOrCreateUserProfile } from '../services/authService'
+import { getTelegramUser } from '../utils/telegram'
 
 export interface ChapterProgress {
   chapterId: number
@@ -29,7 +30,8 @@ export const useUserProgress = (userId?: string | null) => {
         return
       }
       if (/^\d+$/.test(String(userId))) {
-        const username = window.Telegram?.WebApp?.initDataUnsafe?.user?.username || null
+        const tgUser = getTelegramUser()
+        const username = tgUser?.username || null
         const uuid = await findOrCreateUserProfile(String(userId), username)
         setResolvedId(uuid)
       } else {

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,4 +1,5 @@
 import { supabase } from './supabaseClient'
+import { getTelegramUser } from '../utils/telegram'
 
 /**
  * Deterministically convert a Telegram numeric ID into a UUID using
@@ -60,9 +61,9 @@ export async function getCurrentUser() {
     return { id: storedId }
   }
 
-  const tgId = window?.Telegram?.WebApp?.initDataUnsafe?.user?.id
-  if (tgId) {
-    return { id: String(tgId) }
+  const tgUser = getTelegramUser()
+  if (tgUser?.id) {
+    return { id: String(tgUser.id) }
   }
 
   return null

--- a/src/services/progressService.ts
+++ b/src/services/progressService.ts
@@ -1,5 +1,6 @@
 import { supabase } from './supabaseClient'
 import { getCurrentUser, findOrCreateUserProfile } from './authService'
+import { getTelegramUser } from '../utils/telegram'
 
 /**
  * Сохранить ответ пользователя
@@ -32,8 +33,7 @@ export async function saveProgress(
     }
 
     const telegramId = user.id
-    const tgUsername =
-      window?.Telegram?.WebApp?.initDataUnsafe?.user?.username || null
+    const tgUsername = getTelegramUser()?.username || null
     const profileId = await findOrCreateUserProfile(telegramId, tgUsername)
     if (!profileId) {
       console.warn('Could not resolve Telegram ID to UUID')

--- a/src/utils/telegram.ts
+++ b/src/utils/telegram.ts
@@ -1,0 +1,26 @@
+export interface TelegramUser {
+  id: number;
+  first_name?: string;
+  last_name?: string;
+  username?: string;
+  language_code?: string;
+}
+
+/**
+ * Safely retrieve Telegram user from WebApp initDataUnsafe.
+ * Logs warning if data is missing or malformed and returns null.
+ */
+export function getTelegramUser(): TelegramUser | null {
+  const tgUser = (window as any)?.Telegram?.WebApp?.initDataUnsafe?.user;
+  if (!tgUser || !tgUser.id) {
+    console.warn('⚠️ Telegram user data is missing or invalid.');
+    return null;
+  }
+  return {
+    id: tgUser.id,
+    first_name: tgUser.first_name,
+    last_name: tgUser.last_name,
+    username: tgUser.username,
+    language_code: tgUser.language_code
+  };
+}


### PR DESCRIPTION
## Summary
- add helper `getTelegramUser` to safely read Telegram data
- refactor Telegram login flows to use new helper
- ensure navigation bar marks one active item using `useLocation`
- adjust progress saving and profile hooks

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687e21af2cb88324aa0aea7b759017ca