### PR TITLE
Fix total study time recalculation

### DIFF
--- a/src/hooks/useUserProgress.ts
+++ b/src/hooks/useUserProgress.ts
@@ -197,6 +197,16 @@ export const useUserProgress = (userId?: string | null) => {
   }, [progressData])
 
   useEffect(() => {
+    if (progressData.length > 0) {
+      const totalTime = progressData.reduce(
+        (sum: number, p: any) => sum + (p.time_spent || 0),
+        0
+      )
+      setTotalStudyMinutes(Math.floor(totalTime / 60))
+    }
+  }, [progressData])
+
+  useEffect(() => {
     const fetchChapterProgress = async () => {
       if (!resolvedId) return
 


### PR DESCRIPTION
## Summary
- recalc `totalStudyMinutes` whenever `progressData` updates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e3d236b4083249a4c344f5e18feee