### PR TITLE
Simplify account metrics

### DIFF
--- a/src/features/account/AccountStats.tsx
+++ b/src/features/account/AccountStats.tsx
@@ -1,21 +1,17 @@
 import { FC } from 'react'
-import { Clock, Trophy, TrendingUp, CheckCircle } from 'lucide-react'
+import { Calendar, Trophy, TrendingUp, CheckCircle } from 'lucide-react'
 import ProgressBar from '../../components/ui/ProgressBar'
 
 interface AccountStatsProps {
-  totalTime: number
   averageAccuracy: number
   progress: number
   completedChapters: number
   totalChapters: number
+  startDate: string | null
 }
 
-const AccountStats: FC<AccountStatsProps> = ({ totalTime, averageAccuracy, progress, completedChapters, totalChapters }) => (
+const AccountStats: FC<AccountStatsProps> = ({ startDate, averageAccuracy, progress, completedChapters, totalChapters }) => (
   <div className="mt-2 bg-neutral-100 rounded p-2 text-sm text-gray-600 space-y-1">
-    <div className="flex items-center">
-      <Clock className="w-4 h-4 mr-1" />
-      <span>Время обучения: {totalTime}м</span>
-    </div>
     <div className="flex items-center">
       <Trophy className="w-4 h-4 mr-1" />
       <span>Средняя точность: {averageAccuracy}%</span>
@@ -27,6 +23,10 @@ const AccountStats: FC<AccountStatsProps> = ({ totalTime, averageAccuracy, progr
     <div className="flex items-center">
       <CheckCircle className="w-4 h-4 mr-1" />
       <span>Пройдено глав: {completedChapters} из {totalChapters}</span>
+    </div>
+    <div className="flex items-center">
+      <Calendar className="w-4 h-4 mr-1" />
+      <span>Дата начала: {startDate ? new Date(startDate).toLocaleDateString('ru-RU') : '-'}</span>
     </div>
     <ProgressBar percent={progress} />
   </div>

--- a/src/features/account/MyAccount.tsx
+++ b/src/features/account/MyAccount.tsx
@@ -66,7 +66,6 @@ const MyAccount: FC<MyAccountProps> = ({ onBackToHome, onStartChapter }) => {
   const {
     startDate,
     completedChapters,
-    totalStudyMinutes,
     averageAccuracy,
     chapterProgress,
     recommendedChapter,
@@ -241,7 +240,15 @@ const MyAccount: FC<MyAccountProps> = ({ onBackToHome, onStartChapter }) => {
               <span>Выйти</span>
             </button>
           </div>
-          {chapterStats && <AccountStats {...chapterStats} />}
+          {chapterStats && (
+            <AccountStats
+              averageAccuracy={chapterStats.averageAccuracy}
+              progress={chapterStats.progress}
+              completedChapters={chapterStats.completedChapters}
+              totalChapters={chapterStats.totalChapters}
+              startDate={startDate}
+            />
+          )}
         </div>
       </div>
       <div className="p-6">
@@ -250,9 +257,7 @@ const MyAccount: FC<MyAccountProps> = ({ onBackToHome, onStartChapter }) => {
           totalChapters={totalChapters}
           completedSections={completedSections}
           totalSections={totalSections}
-          totalTimeMinutes={totalStudyMinutes}
           averageAccuracy={averageAccuracy}
-          startDate={startDate}
         />
         <ProgressSummary
           correct={progressStats.correct}

--- a/src/features/account/SummaryCards.tsx
+++ b/src/features/account/SummaryCards.tsx
@@ -1,16 +1,14 @@
 import { FC } from 'react'
-import { BookOpen, CheckCircle, Clock, Target, Calendar } from 'lucide-react'
+import { BookOpen, CheckCircle, Target } from 'lucide-react'
 import Card from '../../components/ui/Card'
-import { formatHoursMinutes } from '../../utils/formatTime'
 
 interface SummaryCardsProps {
   completedChapters: number
   totalChapters: number
   completedSections: number
   totalSections: number
-  totalTimeMinutes: number
   averageAccuracy: number
-  startDate: string | null
+  
 }
 
 const SummaryCards: FC<SummaryCardsProps> = ({
@@ -18,9 +16,7 @@ const SummaryCards: FC<SummaryCardsProps> = ({
   totalChapters,
   completedSections,
   totalSections,
-  totalTimeMinutes,
-  averageAccuracy,
-  startDate
+  averageAccuracy
 }) => (
   <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mb-6">
     <Card className="p-4">
@@ -43,28 +39,10 @@ const SummaryCards: FC<SummaryCardsProps> = ({
     </Card>
     <Card className="p-4">
       <div className="flex items-center gap-2">
-        <Clock className="w-6 h-6" />
-        <span className="font-medium">Общее время</span>
-      </div>
-      <div className="text-2xl font-bold mt-2">
-        {formatHoursMinutes(totalTimeMinutes)}
-      </div>
-    </Card>
-    <Card className="p-4">
-      <div className="flex items-center gap-2">
         <Target className="w-6 h-6" />
         <span className="font-medium">Средняя точность</span>
       </div>
       <div className="text-2xl font-bold mt-2">{averageAccuracy}%</div>
-    </Card>
-    <Card className="p-4">
-      <div className="flex items-center gap-2">
-        <Calendar className="w-6 h-6" />
-        <span className="font-medium">Дата начала</span>
-      </div>
-      <div className="text-2xl font-bold mt-2">
-        {startDate ? new Date(startDate).toLocaleDateString('ru-RU') : '-'}
-      </div>
     </Card>
   </div>
 )


### PR DESCRIPTION
## Summary
- update account stats layout
- trim summary cards
- adjust MyAccount props

## Testing
- `npm run lint`
- `npm test`
- `npm run build` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_687e46c7d7388324aa526f9440f54d65