### PR TITLE
Improve account stats layout

### DIFF
--- a/src/features/account/MyAccount.tsx
+++ b/src/features/account/MyAccount.tsx
@@ -10,10 +10,9 @@ import AccountHeader from './AccountHeader'
 import AccountStats from './AccountStats'
 import AccountProgress from './AccountProgress'
 import SectionProgressList from './SectionProgressList'
-import SummaryCards from './SummaryCards'
+import StatsCarousel from './StatsCarousel'
 import useChapterStats from '../../hooks/useChapterStats'
 import useUserProgress from '../../hooks/useUserProgress'
-import ProgressSummary from './ProgressSummary'
 import { getFullUserProgress } from '../../services/progressService'
 import { getTelegramUser } from '../../utils/telegram'
 
@@ -252,18 +251,14 @@ const MyAccount: FC<MyAccountProps> = ({ onBackToHome, onStartChapter }) => {
         </div>
       </div>
       <div className="p-6">
-        <SummaryCards
+        <StatsCarousel
+          totalTime={progressStats.totalTime}
+          averageAccuracy={averageAccuracy}
           completedChapters={completedChaptersCount}
           totalChapters={totalChapters}
           completedSections={completedSections}
           totalSections={totalSections}
-          averageAccuracy={averageAccuracy}
-        />
-        <ProgressSummary
-          correct={progressStats.correct}
-          incorrect={progressStats.incorrect}
-          totalTime={progressStats.totalTime}
-          completedSections={progressStats.completedSections}
+          startDate={startDate}
         />
         {/* Debug info to check saveProgress() calls */}
         <div className="text-sm text-emerald-700 mb-4">

--- a/src/features/account/StatsCarousel.tsx
+++ b/src/features/account/StatsCarousel.tsx
@@ -1,0 +1,70 @@
+import { FC } from 'react'
+import { Clock, Target, BookOpen, ListChecks, Calendar } from 'lucide-react'
+import Card from '../../components/ui/Card'
+
+interface StatsCarouselProps {
+  totalTime: number
+  averageAccuracy: number
+  completedChapters: number
+  totalChapters: number
+  completedSections: number
+  totalSections: number
+  startDate: string | null
+}
+
+const StatsCarousel: FC<StatsCarouselProps> = ({
+  totalTime,
+  averageAccuracy,
+  completedChapters,
+  totalChapters,
+  completedSections,
+  totalSections,
+  startDate
+}) => {
+  const stats = [
+    {
+      label: 'Время обучения',
+      value: `${Math.round(totalTime / 60)} мин`,
+      Icon: Clock
+    },
+    {
+      label: 'Точность',
+      value: `${averageAccuracy}%`,
+      Icon: Target
+    },
+    {
+      label: 'Главы',
+      value: `${completedChapters}/${totalChapters}`,
+      Icon: BookOpen
+    },
+    {
+      label: 'Разделы',
+      value: `${completedSections}/${totalSections}`,
+      Icon: ListChecks
+    },
+    {
+      label: 'Начало',
+      value: startDate ? new Date(startDate).toLocaleDateString('ru-RU') : '-',
+      Icon: Calendar
+    }
+  ]
+
+  return (
+    <div className="overflow-x-auto">
+      <div className="flex space-x-2 p-2 w-max">
+        {stats.map(({ label, value, Icon }) => (
+          <Card
+            key={label}
+            className="min-w-[140px] flex-shrink-0 p-3 flex flex-col items-start"
+          >
+            <Icon className="w-4 h-4 text-emerald-600 mb-1" />
+            <span className="text-xs text-gray-500">{label}</span>
+            <span className="text-lg font-semibold">{value}</span>
+          </Card>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default StatsCarousel


### PR DESCRIPTION
## Summary
- add horizontal `StatsCarousel` component
- replace summary components in `MyAccount` with carousel

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e4f8417d4832481b568194819ba53