### PR TITLE
Improve bottom nav styling

### DIFF
--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -18,25 +18,38 @@ const navItems = [
 
 const BottomNavigation = () => {
   return (
-    <nav className="fixed bottom-0 w-full bg-white border-t border-gray-200 flex justify-around py-2 z-50">
+    <nav className="fixed bottom-0 left-0 right-0 bg-white shadow-md flex justify-around items-center py-2 z-50">
       {navItems.map(({ label, icon: Icon, path, animation }) => (
-        <NavLink
-          key={path}
-          to={path}
-          end
-          className={({ isActive }) =>
-            clsx(
-              BOTTOM_NAV_ITEM_BASE,
-              isActive
-                ? 'text-green-600 font-semibold'
-                : 'text-gray-500 hover:text-green-600'
-            )
-          }
-        >
-          <motion.div whileTap={animation} transition={{ duration: 0.2 }} className="flex flex-col items-center justify-center">
-            <Icon className="w-5 h-5 mb-1" />
-            <span>{label}</span>
-          </motion.div>
+        <NavLink key={path} to={path} end className={BOTTOM_NAV_ITEM_BASE}>
+          {({ isActive }) => (
+            <motion.div
+              whileTap={animation}
+              transition={{ duration: 0.2 }}
+              className={clsx(
+                'flex flex-col items-center',
+                isActive ? 'text-green-600 font-semibold' : 'text-gray-400 hover:text-green-600'
+              )}
+            >
+              <div
+                className={clsx(
+                  'p-2 rounded-full transition-all',
+                  isActive
+                    ? 'ring-2 ring-green-500 text-green-600'
+                    : 'text-gray-400 group-hover:text-green-600'
+                )}
+              >
+                <Icon size={20} />
+              </div>
+              <span
+                className={clsx(
+                  'mt-1 transition-colors',
+                  isActive ? 'font-semibold text-green-600' : 'text-gray-400 group-hover:text-green-600'
+                )}
+              >
+                {label}
+              </span>
+            </motion.div>
+          )}
         </NavLink>
       ))}
     </nav>

--- a/src/utils/classNames.ts
+++ b/src/utils/classNames.ts
@@ -1,3 +1,4 @@
 export const NAV_ITEM_BASE = 'flex flex-col items-center justify-center flex-1 py-2 px-2 transition-all duration-200 transform min-h-[60px] relative';
 export const NAV_ICON_BASE = 'w-6 h-6 mb-1 transition-all duration-200';
-export const BOTTOM_NAV_ITEM_BASE = 'flex-1 flex flex-col items-center justify-center text-xs transition-colors duration-300 ease-in-out';
+export const BOTTOM_NAV_ITEM_BASE =
+  'flex-1 flex flex-col items-center justify-center text-xs transition-all duration-300 ease-in-out group';


### PR DESCRIPTION
## Summary
- tweak bottom nav base style
- highlight active tab with green ring and bold text

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687e53ed79f88324b1c8a76e8f348054