### PR TITLE
Improve section progress UI

### DIFF
--- a/src/features/account/SectionProgressList.tsx
+++ b/src/features/account/SectionProgressList.tsx
@@ -1,4 +1,5 @@
 import { FC } from 'react'
+import clsx from 'clsx'
 
 interface SectionProgressListProps {
   progress: Array<any>
@@ -7,19 +8,29 @@ interface SectionProgressListProps {
 const SectionProgressList: FC<SectionProgressListProps> = ({ progress }) => (
   <div className="bg-white rounded-xl shadow-sm border border-emerald-200 p-6 mb-6">
     <h2 className="text-xl font-semibold text-emerald-900 mb-4">Прогресс по разделам</h2>
-    <ul className="space-y-1 text-sm text-emerald-700">
-      {progress.map(p => (
-        <li key={p.section_id} className="flex justify-between">
-          <span>Раздел {p.section_id}</span>
-          <span className="flex items-center space-x-2">
-            <span>{p.accuracy}%</span>
-            <span className={p.completed ? 'text-green-600' : 'text-red-600'}>
-              {p.completed ? 'Завершён' : 'Не завершён'}
-            </span>
-          </span>
-        </li>
+    <div className="space-y-3">
+      {progress.map(section => (
+        <div key={section.section_id} className="bg-white p-4 rounded-xl shadow">
+          <div className="flex justify-between items-center mb-2">
+            <p className="font-semibold text-gray-800">Раздел {section.section_id}</p>
+            <span className="text-sm text-gray-500">{section.accuracy}%</span>
+          </div>
+          <div className="w-full bg-gray-200 h-2 rounded-full overflow-hidden">
+            <div
+              className={clsx(
+                'h-2 rounded-full transition-all duration-500',
+                section.accuracy <= 30
+                  ? 'bg-red-400'
+                  : section.accuracy <= 70
+                    ? 'bg-yellow-400'
+                    : 'bg-green-500'
+              )}
+              style={{ width: `${section.accuracy}%` }}
+            />
+          </div>
+        </div>
       ))}
-    </ul>
+    </div>
   </div>
 )
 


### PR DESCRIPTION
## Summary
- show progress bars for each section
- color bars depending on progress and animate width

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687e55fa647083249ad1956c95ef9282