### PR TITLE
Fix chat action support for Telegram bot

### DIFF
--- a/src/bot/telegrafWrapper.js
+++ b/src/bot/telegrafWrapper.js
@@ -44,6 +44,10 @@ export default class TelegrafWrapper {
     return this.bot.telegram.answerCbQuery(...args)
   }
 
+  sendChatAction(...args) {
+    return this.bot.telegram.sendChatAction(...args)
+  }
+
   setMyCommands(...args) {
     return this.bot.telegram.setMyCommands(...args)
   }


### PR DESCRIPTION
## Summary
- add missing `sendChatAction` wrapper to TelegrafWrapper

## Testing
- `npm run build` *(fails: cannot find modules and implicit any errors)*

------
https://chatgpt.com/codex/tasks/task_e_687e6c18efa08324982a45223105a1e0