### PR TITLE
Fix TypeScript build failures

### DIFF
--- a/src/components/TelegramLoginRedirect.tsx
+++ b/src/components/TelegramLoginRedirect.tsx
@@ -24,7 +24,10 @@ const TelegramLoginRedirect = () => {
 
     const initProfile = async () => {
       try {
-        const uuid = await findOrCreateUserProfile(userId, telegramUser.username || firstName);
+        const uuid = await findOrCreateUserProfile(
+          userId,
+          telegramUser.username ?? firstName ?? null
+        );
         if (uuid) {
           localStorage.setItem('user_id', uuid);
         }

--- a/src/components/TestInterface.tsx
+++ b/src/components/TestInterface.tsx
@@ -140,6 +140,22 @@ const TestInterface: FC<TestInterfaceProps> = ({ onComplete, onBack }) => {
   const fullQuestions = generateFullQuestionSet();
   const currentQuestionData = fullQuestions[currentQuestion];
 
+  const handleComplete = useCallback(() => {
+    const sectionResults = {
+      reading: answers.filter(a => a.section === 'reading'),
+      writing: answers.filter(a => a.section === 'writing'),
+      listening: answers.filter(a => a.section === 'listening'),
+      grammar: answers.filter(a => a.section === 'grammar')
+    };
+
+    onComplete({
+      totalQuestions: 40,
+      answers,
+      sectionResults,
+      timeSpent: 30 * 60 - timeRemaining
+    });
+  }, [answers, onComplete, timeRemaining]);
+
   useEffect(() => {
     const timer = setInterval(() => {
       setTimeRemaining(prev => {
@@ -208,21 +224,6 @@ const TestInterface: FC<TestInterfaceProps> = ({ onComplete, onBack }) => {
     }
   };
 
-  const handleComplete = useCallback(() => {
-    const sectionResults = {
-      reading: answers.filter(a => a.section === 'reading'),
-      writing: answers.filter(a => a.section === 'writing'),
-      listening: answers.filter(a => a.section === 'listening'),
-      grammar: answers.filter(a => a.section === 'grammar')
-    };
-
-    onComplete({
-      totalQuestions: 40,
-      answers,
-      sectionResults,
-      timeSpent: (30 * 60) - timeRemaining
-    });
-  }, [answers, onComplete, timeRemaining]);
 
   const handleExit = () => {
     if (confirm('Вы уверены, что хотите выйти из теста? Прогресс будет потерян.')) {

--- a/src/features/account/MyAccount.tsx
+++ b/src/features/account/MyAccount.tsx
@@ -226,7 +226,7 @@ const MyAccount: FC<MyAccountProps> = ({ onBackToHome, onStartChapter }) => {
           <div className="flex items-center justify-between">
             <AccountHeader
               username={profile?.username || user?.email?.split('@')[0] || 'Пользователь'}
-              email={user?.email}
+              email={user?.email || undefined}
               isEditing={isEditingUsername}
               newUsername={newUsername}
               onEdit={() => setIsEditingUsername(true)}

--- a/src/hooks/useSupabaseAuth.ts
+++ b/src/hooks/useSupabaseAuth.ts
@@ -10,6 +10,7 @@ import { getUserStats, getUserAchievements } from '../services/progressService'
 
 export interface AuthUser {
   id: string
+  email?: string | null
 }
 
 export interface UserProfile {
@@ -82,10 +83,10 @@ export function useSupabaseAuth(): UseSupabaseAuthResult {
 
       if (profileError) throw profileError
 
-      const [userStats, userAchievements] = await Promise.all([
-        getUserStats(userProfile.id) as Promise<UserStats>,
-        getUserAchievements(userProfile.id)
-      ])
+        const [userStats, userAchievements] = await Promise.all([
+          getUserStats() as Promise<UserStats>,
+          getUserAchievements()
+        ])
 
       setUser({ id: identifier })
       setProfile(userProfile)
@@ -93,7 +94,7 @@ export function useSupabaseAuth(): UseSupabaseAuthResult {
       setAchievements(userAchievements)
     } catch (err) {
       console.error('Ошибка загрузки данных пользователя:', err)
-      setError(err.message)
+      setError(err instanceof Error ? err.message : String(err))
     } finally {
       setLoading(false)
     }
@@ -113,7 +114,9 @@ export function useSupabaseAuth(): UseSupabaseAuthResult {
           String(tgUser.id),
           tgUser.username || tgUser.first_name || null
         )
-        localStorage.setItem('user_id', uuid)
+        if (uuid) {
+          localStorage.setItem('user_id', uuid)
+        }
         localStorage.setItem('telegram_id', String(tgUser.id))
         await loadUserData(String(tgUser.id))
       } catch (err) {
@@ -135,7 +138,7 @@ export function useSupabaseAuth(): UseSupabaseAuthResult {
       setUser(null)
       setProfile(null)
     } catch (err) {
-      setError(err.message)
+      setError(err instanceof Error ? err.message : String(err))
       throw err
     } finally {
       setLoading(false)
@@ -157,7 +160,7 @@ export function useSupabaseAuth(): UseSupabaseAuthResult {
       setProfile(updated)
       return updated
     } catch (err) {
-      setError(err.message)
+      setError(err instanceof Error ? err.message : String(err))
       throw err
     } finally {
       setLoading(false)


### PR DESCRIPTION
## Summary
- pass Telegram username or first name safely
- ensure test interface defines `handleComplete` before use
- allow null user email in account header
- expand `AuthUser` type and fix error handling

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687e6d6013348324838cd37930feb64c