### PR TITLE
Improve Telegraf context typings

### DIFF
--- a/src/bot/commands.js
+++ b/src/bot/commands.js
@@ -33,7 +33,7 @@ import {
 /**
  * Handle the /start command
  * ИСПРАВЛЕНО: Улучшенная обработка ошибок и логирование
- * @param {import("telegraf").Context} ctx - Telegraf context
+ * @param {import("telegraf").Context & { message: import('@telegraf/types').Message.TextMessage }} ctx - Telegraf context
  */
 export function handleStartCommand(ctx) {
   const chatId = ctx.chat.id;
@@ -125,7 +125,7 @@ export function handleStartCommand(ctx) {
 
 /**
  * Handle the /help command
- * @param {import("telegraf").Context} ctx - Telegraf context
+ * @param {import("telegraf").Context & { message: import('@telegraf/types').Message.TextMessage }} ctx - Telegraf context
  */
 export function handleHelpCommand(ctx) {
   const chatId = ctx.chat.id;
@@ -186,7 +186,7 @@ export function handleHelpCommand(ctx) {
 
 /**
  * Handle the /webapp command
- * @param {import("telegraf").Context} ctx - Telegraf context
+ * @param {import("telegraf").Context & { message: import('@telegraf/types').Message.TextMessage }} ctx - Telegraf context
  */
 export function handleWebAppCommand(ctx) {
   const chatId = ctx.chat.id;
@@ -228,7 +228,7 @@ export function handleWebAppCommand(ctx) {
 
 /**
  * Handle the /chapters command
- * @param {import("telegraf").Context} ctx - Telegraf context
+ * @param {import("telegraf").Context & { message: import('@telegraf/types').Message.TextMessage }} ctx - Telegraf context
  */
 export function handleChaptersCommand(ctx) {
   const chatId = ctx.chat.id;
@@ -271,7 +271,7 @@ export function handleChaptersCommand(ctx) {
 
 /**
  * Handle the /test command
- * @param {import("telegraf").Context} ctx - Telegraf context
+ * @param {import("telegraf").Context & { message: import('@telegraf/types').Message.TextMessage }} ctx - Telegraf context
  */
 export function handleTestCommand(ctx) {
   const chatId = ctx.chat.id;
@@ -344,7 +344,7 @@ export function handleTestCommand(ctx) {
 /**
  * Handle the /profile command
  * ИСПРАВЛЕНО: Показываем реальный прогресс пользователя
- * @param {import("telegraf").Context} ctx - Telegraf context
+ * @param {import("telegraf").Context & { message: import('@telegraf/types').Message.TextMessage }} ctx - Telegraf context
  */
 export function handleProfileCommand(ctx) {
   const chatId = ctx.chat.id;
@@ -397,7 +397,7 @@ export function handleProfileCommand(ctx) {
 
 /**
  * Handle callback queries
- * @param {import("telegraf").Context} ctx - Telegraf context
+ * @param {import("telegraf").Context & { callbackQuery: import('@telegraf/types').CallbackQuery.DataCallbackQuery }} ctx - Telegraf context
  */
 export function handleCallbackQuery(ctx) {
   const callbackQuery = ctx.callbackQuery;
@@ -501,7 +501,7 @@ export function handleCallbackQuery(ctx) {
 
 /**
  * Handle chapter selection
- * @param {import("telegraf").Context} ctx - Telegraf context
+ * @param {import("telegraf").Context & { message: import('@telegraf/types').Message.TextMessage }} ctx - Telegraf context
  * @param {number} chapterId - Selected chapter ID
  */
 export function handleChapterSelection(ctx, chapterId) {
@@ -571,7 +571,7 @@ export function handleChapterSelection(ctx, chapterId) {
 
 /**
  * Handle section selection
- * @param {import("telegraf").Context} ctx - Telegraf context
+ * @param {import("telegraf").Context & { message: import('@telegraf/types').Message.TextMessage }} ctx - Telegraf context
  * @param {number} chapterId - Chapter ID
  * @param {number} sectionId - Selected section ID
  */

--- a/src/bot/handlers/quizHandler.js
+++ b/src/bot/handlers/quizHandler.js
@@ -11,7 +11,7 @@ import {
 
 /**
  * Start a quiz for a user
- * @param {import('telegraf').Context} ctx - Telegraf context
+ * @param {import('telegraf').Context & { message: import('@telegraf/types').Message.TextMessage }} ctx - Telegraf context
  */
 export function startQuiz(ctx) {
   const chatId = ctx.chat.id;
@@ -32,7 +32,7 @@ export function startQuiz(ctx) {
 
 /**
  * Send a quiz question to the user
- * @param {import('telegraf').Context} ctx - Telegraf context
+ * @param {import('telegraf').Context & { message: import('@telegraf/types').Message.TextMessage }} ctx - Telegraf context
  */
 export function sendQuizQuestion(ctx) {
   const chatId = ctx.chat.id;
@@ -65,7 +65,7 @@ export function sendQuizQuestion(ctx) {
 
 /**
  * Handle a quiz answer
- * @param {import('telegraf').Context} ctx - Telegraf context
+ * @param {import('telegraf').Context & { message: import('@telegraf/types').Message.TextMessage }} ctx - Telegraf context
  */
 export function handleQuizAnswer(ctx) {
   const chatId = ctx.chat.id;
@@ -119,7 +119,7 @@ export function handleQuizAnswer(ctx) {
 
 /**
  * Finish a quiz and show results
- * @param {import('telegraf').Context} ctx - Telegraf context
+ * @param {import('telegraf').Context & { message: import('@telegraf/types').Message.TextMessage }} ctx - Telegraf context
  */
 export function finishQuiz(ctx) {
   const chatId = ctx.chat.id;

--- a/src/bot/index.js
+++ b/src/bot/index.js
@@ -203,7 +203,7 @@ async function setupBotCommands() {
 }
 
 // Enhanced command handlers with better error handling
-bot.hears(/\/start/, async (ctx) => {
+bot.hears(/\/start/, async (/** @type {import('telegraf').Context & { message: import('@telegraf/types').Message.TextMessage }} */ ctx) => {
   const msg = ctx.message;
   const userId = msg.from.id;
   const userName = msg.from.first_name;
@@ -225,7 +225,7 @@ bot.hears(/\/start/, async (ctx) => {
   }
 });
 
-bot.hears(/\/help/, async (ctx) => {
+bot.hears(/\/help/, async (/** @type {import('telegraf').Context & { message: import('@telegraf/types').Message.TextMessage }} */ ctx) => {
   const msg = ctx.message;
   console.log(`📨 Получена команда /help от пользователя ${msg.from.id}`);
   try {
@@ -237,7 +237,7 @@ bot.hears(/\/help/, async (ctx) => {
   }
 });
 
-bot.hears(/\/webapp/, async (ctx) => {
+bot.hears(/\/webapp/, async (/** @type {import('telegraf').Context & { message: import('@telegraf/types').Message.TextMessage }} */ ctx) => {
   const msg = ctx.message;
   console.log(`📨 Получена команда /webapp от пользователя ${msg.from.id}`);
   try {
@@ -249,7 +249,7 @@ bot.hears(/\/webapp/, async (ctx) => {
   }
 });
 
-bot.hears(/\/chapters/, async (ctx) => {
+bot.hears(/\/chapters/, async (/** @type {import('telegraf').Context & { message: import('@telegraf/types').Message.TextMessage }} */ ctx) => {
   const msg = ctx.message;
   console.log(`📨 Получена команда /chapters от пользователя ${msg.from.id}`);
   try {
@@ -261,7 +261,7 @@ bot.hears(/\/chapters/, async (ctx) => {
   }
 });
 
-bot.hears(/\/test/, async (ctx) => {
+bot.hears(/\/test/, async (/** @type {import('telegraf').Context & { message: import('@telegraf/types').Message.TextMessage }} */ ctx) => {
   const msg = ctx.message;
   console.log(`📨 Получена команда /test от пользователя ${msg.from.id}`);
   try {
@@ -273,7 +273,7 @@ bot.hears(/\/test/, async (ctx) => {
   }
 });
 
-bot.hears(/\/profile/, async (ctx) => {
+bot.hears(/\/profile/, async (/** @type {import('telegraf').Context & { message: import('@telegraf/types').Message.TextMessage }} */ ctx) => {
   const msg = ctx.message;
   console.log(`📨 Получена команда /profile от пользователя ${msg.from.id}`);
   try {
@@ -286,7 +286,7 @@ bot.hears(/\/profile/, async (ctx) => {
 });
 
 // Enhanced debug command
-bot.hears(/\/debug/, async (ctx) => {
+bot.hears(/\/debug/, async (/** @type {import('telegraf').Context & { message: import('@telegraf/types').Message.TextMessage }} */ ctx) => {
   const msg = ctx.message;
   console.log(`📨 Получена команда /debug от пользователя ${msg.from.id}`);
   try {
@@ -327,7 +327,7 @@ bot.hears(/\/debug/, async (ctx) => {
 });
 
 // Enhanced callback query handler
-bot.on('callback_query', async (ctx) => {
+bot.on('callback_query', async (/** @type {import('telegraf').Context & { callbackQuery: import('@telegraf/types').CallbackQuery.DataCallbackQuery }} */ ctx) => {
   const callbackQuery = ctx.callbackQuery;
   console.log(`🔘 Получен callback query: ${callbackQuery.data} от пользователя ${callbackQuery.from.id}`);
   try {
@@ -340,7 +340,7 @@ bot.on('callback_query', async (ctx) => {
 });
 
 // Enhanced WebApp data handler
-bot.on('message', async (ctx) => {
+bot.on('message', async (/** @type {import('telegraf').Context & { message: import('@telegraf/types').Message.TextMessage }} */ ctx) => {
   if (ctx.message.web_app_data?.data) {
     console.log(`🌐 Получены данные WebApp от пользователя ${ctx.from.id}`);
     try {
@@ -386,7 +386,7 @@ ${webAppData.score >= 80 ? '🏆 Отличный результат!' :
 });
 
 // Handle chapter selection by number
-bot.hears(/^([1-9]|1[0-4])$/, async (ctx) => {
+bot.hears(/^([1-9]|1[0-4])$/, async (/** @type {import('telegraf').Context & { message: import('@telegraf/types').Message.TextMessage }} */ ctx) => {
   const msg = ctx.message;
   const match = ctx.match;
   console.log(`📖 Выбор главы ${match[1]} пользователем ${msg.from.id}`);
@@ -401,7 +401,7 @@ bot.hears(/^([1-9]|1[0-4])$/, async (ctx) => {
 });
 
 // Handle section selection (format: chapter.section, e.g., "1.2")
-bot.hears(/^([1-9]|1[0-4])\.([1-5])$/, async (ctx) => {
+bot.hears(/^([1-9]|1[0-4])\.([1-5])$/, async (/** @type {import('telegraf').Context & { message: import('@telegraf/types').Message.TextMessage }} */ ctx) => {
   const msg = ctx.message;
   const match = ctx.match;
   console.log(`📑 Выбор раздела ${match[1]}.${match[2]} пользователем ${msg.from.id}`);
@@ -417,7 +417,7 @@ bot.hears(/^([1-9]|1[0-4])\.([1-5])$/, async (ctx) => {
 });
 
 // Handle all other messages
-bot.on('message', async (ctx) => {
+bot.on('message', async (/** @type {import('telegraf').Context & { message: import('@telegraf/types').Message.TextMessage }} */ ctx) => {
   const msg = ctx.message;
   // Skip command messages and handled patterns
   if (msg.text && (

--- a/src/bot/messageHandler.js
+++ b/src/bot/messageHandler.js
@@ -11,7 +11,7 @@ import { esperantoChapters, basicPhrases } from './data/esperantoData.js';
 
 /**
  * Handle incoming messages
- * @param {import('telegraf').Context} ctx - Telegraf context
+ * @param {import('telegraf').Context & { message: import('@telegraf/types').Message.TextMessage }} ctx - Telegraf context
  * @param {Object} openAIService - The OpenAI service
  */
 export async function handleMessage(ctx, openAIService) {
@@ -104,7 +104,7 @@ export async function handleMessage(ctx, openAIService) {
 
 /**
  * Process message with OpenAI
- * @param {import('telegraf').Context} ctx - Telegraf context
+ * @param {import('telegraf').Context & { message: import('@telegraf/types').Message.TextMessage }} ctx - Telegraf context
  * @param {Object} openAIService - The OpenAI service
  * @param {number} userId - User ID
  * @param {number} chatId - Chat ID


### PR DESCRIPTION
## Summary
- tighten type hints for Telegraf context usage

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687e941a7ccc8324ba870e2d508424ea