### PR TITLE
Add bot command tests and fix async handler

### DIFF
--- a/src/bot/commands.js
+++ b/src/bot/commands.js
@@ -399,7 +399,7 @@ export function handleProfileCommand(ctx) {
  * Handle callback queries
  * @param {import("telegraf").Context & { callbackQuery: import('@telegraf/types').CallbackQuery.DataCallbackQuery }} ctx - Telegraf context
  */
-export function handleCallbackQuery(ctx) {
+export async function handleCallbackQuery(ctx) {
   const callbackQuery = ctx.callbackQuery;
   const chatId = callbackQuery.message.chat.id;
   const userId = callbackQuery.from.id;

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { handleStartCommand, handleCallbackQuery } from '../src/bot/commands.js'
+import { startQuiz } from '../src/bot/handlers/quizHandler.js'
+
+// Helper to create mock Telegraf context
+function createCtx() {
+  const ctx = {
+    chat: { id: 1 },
+    from: { id: 1, first_name: 'Tester' },
+    calls: [],
+    telegram: {
+      sendMessage: (...args) => {
+        ctx.calls.push({ method: 'sendMessage', args })
+        return Promise.resolve()
+      }
+    },
+    answerCbQuery: (...args) => {
+      ctx.calls.push({ method: 'answerCbQuery', args })
+      return Promise.resolve()
+    }
+  }
+  return ctx
+}
+
+// /start command should send welcome message
+test('handleStartCommand sends welcome text', async () => {
+  const ctx = createCtx()
+  handleStartCommand(ctx)
+  // wait microtask chain
+  await Promise.resolve()
+  assert.ok(ctx.calls.some(c => c.method === 'sendMessage'))
+})
+
+// startQuiz should send first question
+test('startQuiz sends first question', async () => {
+  const ctx = createCtx()
+  startQuiz(ctx)
+  await Promise.resolve()
+  assert.ok(ctx.calls.some(c => c.method === 'sendMessage'))
+})
+
+// handleCallbackQuery responds to start_test
+test('handleCallbackQuery start_test', async () => {
+  const ctx = createCtx()
+  ctx.callbackQuery = {
+    id: 'cb1',
+    data: 'start_test',
+    from: ctx.from,
+    message: { chat: ctx.chat }
+  }
+  await handleCallbackQuery(ctx)
+  assert.ok(ctx.calls.some(c => c.method === 'answerCbQuery'))
+  assert.ok(ctx.calls.some(c => c.method === 'sendMessage'))
+})


### PR DESCRIPTION
## Summary
- cover Telegram bot logic with new tests
- mark `handleCallbackQuery` as async so it can `await`

## Testing
- `node --experimental-test-coverage --test`

------
https://chatgpt.com/codex/tasks/task_e_687e97373590832481dc1ce492b2f25b