### PR TITLE
Add Render deployment config

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,17 @@
+services:
+  - type: web
+    name: esperanto-telegram-bot
+    env: node
+    plan: free
+    buildCommand: npm install
+    startCommand: npm run bot
+    envVars:
+      - key: BOT_TOKEN
+        value: your-real-bot-token
+      - key: SUPABASE_URL
+        value: https://your.supabase.co
+      - key: SUPABASE_KEY
+        value: your-supabase-service-key
+      - key: OPENAI_API_KEY
+        value: sk-...
+    autoDeploy: true


### PR DESCRIPTION
## Summary
- add `render.yaml` with Render service configuration for the bot

## Testing
- `npm test`
- `npm install` *(fails: ECONNRESET)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_687ec326146083248e33dfa00e0029a7