### PR TITLE
Add Telegram profile sync service

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,15 @@
-import { Home, FileText, Bot, User } from 'lucide-react';
-import { Routes, Route } from 'react-router-dom';
-import type { NavigationItem } from './components/NavigationBar';
-import MainLayout from './layout/MainLayout';
-import LearningPage from './pages/LearningPage';
-import TestPage from './pages/TestPage';
-import AIChatPage from './pages/AIChatPage';
-import AccountPage from './pages/AccountPage';
-import LandingPage from './pages/LandingPage';
+import { Home, FileText, Bot, User } from 'lucide-react'
+import { Routes, Route } from 'react-router-dom'
+import { useEffect } from 'react'
+import type { NavigationItem } from './components/NavigationBar'
+import MainLayout from './layout/MainLayout'
+import LearningPage from './pages/LearningPage'
+import TestPage from './pages/TestPage'
+import AIChatPage from './pages/AIChatPage'
+import AccountPage from './pages/AccountPage'
+import LandingPage from './pages/LandingPage'
+import { useTelegramUser } from './hooks/useTelegramUser'
+import { syncTelegramProfile } from './services/syncTelegramProfile'
 
 const navItems: NavigationItem[] = [
   { id: 'home', label: 'Главная', icon: Home, path: '/' },
@@ -16,6 +19,17 @@ const navItems: NavigationItem[] = [
 ];
 
 function App() {
+  const telegramUser = useTelegramUser()
+
+  useEffect(() => {
+    if (telegramUser) {
+      syncTelegramProfile(telegramUser).then(profile => {
+        console.log('Профиль пользователя синхронизирован:', profile)
+        // Можно сохранить UUID в стейт, localStorage или context
+      })
+    }
+  }, [telegramUser])
+
   return (
     <MainLayout items={navItems}>
       <Routes>
@@ -26,7 +40,7 @@ function App() {
         <Route path="/landing" element={<LandingPage />} />
       </Routes>
     </MainLayout>
-  );
+  )
 }
 
 export default App;

--- a/src/services/syncTelegramProfile.ts
+++ b/src/services/syncTelegramProfile.ts
@@ -1,0 +1,41 @@
+import { supabase } from './supabaseClient'
+
+export async function syncTelegramProfile(telegramUser: any) {
+  if (!telegramUser?.id) return null
+
+  const telegramId = telegramUser.id
+
+  const { data: existing, error: searchError } = await supabase
+    .from('profiles')
+    .select('*')
+    .eq('telegram_id', telegramId)
+    .single()
+
+  if (searchError && searchError.code !== 'PGRST116') {
+    console.warn('Ошибка при поиске профиля:', searchError.message)
+    return null
+  }
+
+  if (existing) {
+    return existing
+  }
+
+  const { data: created, error: insertError } = await supabase
+    .from('profiles')
+    .insert({
+      telegram_id: telegramId,
+      first_name: telegramUser.first_name,
+      last_name: telegramUser.last_name || '',
+      username: telegramUser.username || '',
+      language_code: telegramUser.language_code || ''
+    })
+    .select()
+    .single()
+
+  if (insertError) {
+    console.error('Ошибка при создании профиля:', insertError.message)
+    return null
+  }
+
+  return created
+}


### PR DESCRIPTION
## Summary
- add a dedicated `syncTelegramProfile` service that ensures a Telegram user's profile exists in Supabase
- call this new service from `App` when Telegram user info is available

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687ed15e3b08832484d3b54cfb6e9779