### PR TITLE
Implement user context

### DIFF
--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -1,0 +1,29 @@
+import { createContext, useContext, useState, useEffect } from 'react';
+import { useTelegramUser } from '../hooks/useTelegramUser';
+import { syncTelegramProfile } from '../services/syncTelegramProfile';
+
+export const UserContext = createContext<{ userId: string | null }>({ userId: null });
+
+export const UserProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const telegramUser = useTelegramUser();
+  const [userId, setUserId] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function fetchOrCreate() {
+      if (telegramUser) {
+        const profile = await syncTelegramProfile(telegramUser);
+        if (profile?.id) {
+          setUserId(profile.id);
+          localStorage.setItem('user_id', profile.id); // optional fallback
+        }
+      }
+    }
+    fetchOrCreate();
+  }, [telegramUser]);
+
+  return <UserContext.Provider value={{ userId }}>{children}</UserContext.Provider>;
+};
+
+export function useUserId() {
+  return useContext(UserContext).userId;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,7 @@ import './index.css';
 import { SupabaseAuthProvider } from './components/SupabaseAuthProvider';
 import { TelegramWebAppProvider } from './components/TelegramWebAppProvider';
 import TelegramLoginRedirect from './components/TelegramLoginRedirect';
+import { UserProvider } from './context/UserContext';
 
 const root = createRoot(document.getElementById('root')!);
 
@@ -17,11 +18,13 @@ root.render(
       {/* the Telegram provider can access authentication context */}
       <SupabaseAuthProvider>
         <TelegramWebAppProvider>
-          <TelegramLoginRedirect />
-          <Routes>
-            <Route path="/admin-panel" element={<AdminPanelPage />} />
-            <Route path="/*" element={<App />} />
-          </Routes>
+          <UserProvider>
+            <TelegramLoginRedirect />
+            <Routes>
+              <Route path="/admin-panel" element={<AdminPanelPage />} />
+              <Route path="/*" element={<App />} />
+            </Routes>
+          </UserProvider>
         </TelegramWebAppProvider>
       </SupabaseAuthProvider>
     </BrowserRouter>

--- a/src/pages/MyAccount.tsx
+++ b/src/pages/MyAccount.tsx
@@ -1,0 +1,9 @@
+import { useUserId } from '../context/UserContext';
+
+function MyAccount() {
+  const userId = useUserId();
+
+  return <div>Ваш UUID: {userId}</div>;
+}
+
+export default MyAccount;


### PR DESCRIPTION
## Summary
- create `UserContext` and `UserProvider`
- wrap app with `UserProvider`
- add a minimal `MyAccount` page that shows stored UUID

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687ed358cad88324905bad5835086c4f