### PR TITLE
Bind progress saving to user context

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,13 @@ await saveTestResult({
 Пример кода:
 
 ```ts
-await saveProgress()
+await saveProgress({
+  chapterId: 1,
+  sectionId: 2,
+  questionId: 3,
+  selectedAnswer: 'A',
+  isCorrect: true,
+})
 await saveTestResults()
 await checkAndAssignAchievements()
 router.push(`/section/${nextSectionId}`)

--- a/src/components/QuestionInterface.tsx
+++ b/src/components/QuestionInterface.tsx
@@ -136,15 +136,15 @@ const QuestionInterface: FC<QuestionInterfaceProps> = ({
     }
 
     try {
-      await saveProgress(
+      await saveProgress({
         chapterId,
         sectionId,
-        currentQuestionData.id,
-        answer,
-        correct,
-        0,
-        hintsUsed
-      )
+        questionId: currentQuestionData.id,
+        selectedAnswer: answer,
+        isCorrect: correct,
+        timeSpent: 0,
+        hintsUsed,
+      })
       await refreshStats()
     } catch (err) {
       console.error('Ошибка сохранения ответа:', err)


### PR DESCRIPTION
## Summary
- store user progress using user_id from context
- adjust question interface to pass new saveProgress options
- simplify section completion upsert logic using context user id
- document new saveProgress call signature

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ed597d5c48324a3f6b9a911453e38