### PR TITLE
Configure Render SPA fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="apple-mobile-web-app-title" content="Esperanto-Leto" />
-    <title>Esperanto-Leto Telegram WebApp</title>
+    <title>Esperanto-Leto</title>
     
     <!-- Telegram WebApp Script -->
     <script src="https://telegram.org/js/telegram-web-app.js"></script>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,7 @@ export default defineConfig(({ mode }) => {
   }
 
   return {
+    base: '/',
     plugins: [react()],
     test: {
       environment: 'jsdom',
@@ -23,6 +24,7 @@ export default defineConfig(({ mode }) => {
     server: {
       host: true,
       port: 5173,
+      historyApiFallback: true,
     },
     build: {
       outDir: 'dist',


### PR DESCRIPTION
## Summary
- enable history fallback for Render SPA
- ensure root document head sets minimal meta

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687f5988c6f883248420ba326e5b0cd3