### PR TITLE
Fix Vite env define

### DIFF
--- a/src/services/progressService.ts
+++ b/src/services/progressService.ts
@@ -1,6 +1,5 @@
 import { supabase } from './supabaseClient'
 import { getCurrentUser } from './authService'
-import { useUserId } from '../context/UserContext'
 
 /**
  * Сохранить ответ пользователя
@@ -34,7 +33,8 @@ export async function saveProgress({
     // Отмечаем вызов функции в localStorage для отладки
     localStorage.setItem('saveProgress_called', new Date().toISOString())
 
-    const userId = useUserId()
+    const currentUser = await getCurrentUser()
+    const userId = currentUser?.id
     if (!userId) {
       console.warn('userId not available')
       return null

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -32,7 +32,8 @@ export default defineConfig(({ mode }) => {
     },
     publicDir: 'public',
     define: {
-      'process.env': env,
+      'process.env.VITE_SUPABASE_URL': JSON.stringify(env.VITE_SUPABASE_URL),
+      'process.env.VITE_SUPABASE_ANON_KEY': JSON.stringify(env.VITE_SUPABASE_ANON_KEY),
     },
   };
 });


### PR DESCRIPTION
## Summary
- restrict Vite `define` block to only expose Supabase variables
- avoid React hook usage in `saveProgress`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687f5e919f548324b03d5006c96c3736