### PR TITLE
Update web_app URL handling

### DIFF
--- a/src/bot/commands.js
+++ b/src/bot/commands.js
@@ -16,10 +16,15 @@ import { esperantoChapters } from './data/esperantoData.js';
 const BOT_USERNAME = process.env.BOT_USERNAME || 'YOUR_BOT_USERNAME';
 
 function buildWebAppUrl(params = {}) {
-  const base = `https://t.me/${BOT_USERNAME}/webapp`;
+  const envUrl = process.env.WEBAPP_URL;
+  const base = envUrl && envUrl.startsWith('https://')
+    ? envUrl
+    : `https://t.me/${BOT_USERNAME}/webapp`;
+
   if (params && Object.keys(params).length > 0) {
     const search = new URLSearchParams(params);
-    return `${base}?startapp=${encodeURIComponent(search.toString())}`;
+    const query = base.includes('?') ? `&${search.toString()}` : `?${search.toString()}`;
+    return `${base}${query}`;
   }
   return base;
 }

--- a/src/bot/utils/keyboard.js
+++ b/src/bot/utils/keyboard.js
@@ -5,10 +5,15 @@
 const BOT_USERNAME = process.env.BOT_USERNAME || 'YOUR_BOT_USERNAME';
 
 function buildWebAppUrl(params = {}) {
-  const base = `https://t.me/${BOT_USERNAME}/webapp`;
+  const envUrl = process.env.WEBAPP_URL;
+  const base = envUrl && envUrl.startsWith('https://')
+    ? envUrl
+    : `https://t.me/${BOT_USERNAME}/webapp`;
+
   if (params && Object.keys(params).length > 0) {
     const search = new URLSearchParams(params);
-    return `${base}?startapp=${encodeURIComponent(search.toString())}`;
+    const query = base.includes('?') ? `&${search.toString()}` : `?${search.toString()}`;
+    return `${base}${query}`;
   }
   return base;
 }


### PR DESCRIPTION
## Summary
- generate Telegram Web App links using the `WEBAPP_URL` env var
- keep fallback to the old `t.me/.../webapp` link

## Testing
- `npm test`
- `npm run lint`
- `npm run bot` *(fails: `WEBAPP_URL` and other secrets not set)*

------
https://chatgpt.com/codex/tasks/task_e_687f5f52b56c832480ddaf400f311a19