### PR TITLE
Fix dotenv config for Render

### DIFF
--- a/src/bot/index.js
+++ b/src/bot/index.js
@@ -1,4 +1,10 @@
-import 'dotenv/config';
+// Load environment variables from .env in local development
+// Skip when running on the Render platform where variables are preconfigured
+if (!process.env.RENDER) {
+  const dotenv = await import('dotenv');
+  dotenv.config();
+}
+console.log('✅ Переменные загружены из окружения:', Object.keys(process.env));
 
 import { Telegraf } from 'telegraf';
 import express from 'express';


### PR DESCRIPTION
## Summary
- conditionally load dotenv in the bot only in local dev
- show env vars loaded for easier debugging

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687f689860e48324a03a3e2459f0773f