### PR TITLE
Remove unused OpenAI key check

### DIFF
--- a/src/bot/index.js
+++ b/src/bot/index.js
@@ -71,9 +71,9 @@ console.log('=' .repeat(50));
 console.log('📋 Проверка переменных окружения:');
 const requiredEnvVars = {
   TELEGRAM_BOT_TOKEN: process.env.TELEGRAM_BOT_TOKEN,
-  WEBAPP_URL: process.env.WEBAPP_URL,
-  OPENAI_API_KEY: process.env.OPENAI_API_KEY
+  WEBAPP_URL: process.env.WEBAPP_URL
 };
+console.log('ℹ️ OPENAI_API_KEY не используется — пропускаем проверку');
 
 let hasErrors = false;
 for (const [key, value] of Object.entries(requiredEnvVars)) {
@@ -93,7 +93,7 @@ if (hasErrors) {
   console.error('\nПример правильного .env файла:');
   console.error('TELEGRAM_BOT_TOKEN=123456789:ABCdefGHIjklMNOpqrSTUvwxyz-1234567890');
   console.error('WEBAPP_URL=https://your-domain.com');
-  console.error('OPENAI_API_KEY=your_openai_api_key');
+  // console.error('OPENAI_API_KEY=your_openai_api_key');
   process.exit(1);
 }
 


### PR DESCRIPTION
## Summary
- skip OPENAI_API_KEY validation in the bot startup

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687f69fa95f08324bc608fa6ae4d0b2e