### PR TITLE
Add intro splash screen

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { Home, FileText, Bot, User } from 'lucide-react'
 import { Routes, Route } from 'react-router-dom'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import type { NavigationItem } from './components/NavigationBar'
 import MainLayout from './layout/MainLayout'
 import LearningPage from './pages/LearningPage'
@@ -8,6 +8,7 @@ import TestPage from './pages/TestPage'
 import AIChatPage from './pages/AIChatPage'
 import AccountPage from './pages/AccountPage'
 import LandingPage from './pages/LandingPage'
+import LoadingVideo from './components/LoadingVideo'
 import { useTelegramUser } from './hooks/useTelegramUser'
 import { syncTelegramProfile } from './services/syncTelegramProfile'
 
@@ -20,6 +21,13 @@ const navItems: NavigationItem[] = [
 
 function App() {
   const telegramUser = useTelegramUser()
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    if (localStorage.getItem('intro_seen') === '1') {
+      setLoading(false)
+    }
+  }, [])
 
   useEffect(() => {
     if (telegramUser) {
@@ -29,6 +37,15 @@ function App() {
       })
     }
   }, [telegramUser])
+
+  const handleIntroFinish = () => {
+    localStorage.setItem('intro_seen', '1')
+    setLoading(false)
+  }
+
+  if (loading) {
+    return <LoadingVideo onFinish={handleIntroFinish} />
+  }
 
   return (
     <MainLayout items={navItems}>

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -2,6 +2,10 @@ import { render, screen } from '@testing-library/react';
 import App from '../App';
 import { MemoryRouter } from 'react-router-dom';
 
+beforeEach(() => {
+  localStorage.setItem('intro_seen', '1');
+});
+
 test('renders navigation labels', () => {
   render(<MemoryRouter initialEntries={['/ai']}><App /></MemoryRouter>);
   expect(screen.getAllByText(/Главная/i)[0]).toBeInTheDocument();

--- a/src/components/LoadingVideo.tsx
+++ b/src/components/LoadingVideo.tsx
@@ -1,18 +1,47 @@
-import React from 'react';
-import loadingVideo from '../assets/loading.mp4';
+import { useEffect, useRef } from 'react';
 
-const LoadingVideo: React.FC = () => (
-  <div className="fixed inset-0 z-40 bg-black pb-[70px]">
-    <video
-      src={loadingVideo}
-      autoPlay
-      muted
-      loop
-      playsInline
-      preload="auto"
-      className="w-full h-full object-cover"
-    />
-  </div>
-);
+interface LoadingVideoProps {
+  onFinish: () => void;
+}
+
+const LoadingVideo: React.FC<LoadingVideoProps> = ({ onFinish }) => {
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  useEffect(() => {
+    const video = videoRef.current;
+    const fallback = setTimeout(() => onFinish(), 12000);
+
+    if (video) {
+      const playPromise = video.play();
+      if (playPromise !== undefined) {
+        playPromise.catch(() => {
+          const resume = () => {
+            video.play().catch(() => {});
+          };
+          document.addEventListener('click', resume, { once: true });
+        });
+      }
+    }
+
+    return () => {
+      clearTimeout(fallback);
+    };
+  }, [onFinish]);
+
+  return (
+    <div className="fixed inset-0 z-50">
+      <video
+        ref={videoRef}
+        src="/start-loading.mp4"
+        autoPlay
+        muted
+        playsInline
+        preload="auto"
+        onEnded={onFinish}
+        className="w-full h-full object-cover"
+      />
+    </div>
+  );
+};
 
 export default LoadingVideo;


### PR DESCRIPTION
## Summary
- implement `<LoadingVideo>` that handles autoplay and fallback timeout
- show the intro video on first launch in `App`
- update app tests for new splash screen behavior

## Testing
- `npm test`
- `VITE_SUPABASE_URL=http://localhost VITE_SUPABASE_ANON_KEY=dummy npm run test:ui`


------
https://chatgpt.com/codex/tasks/task_e_687f8a8879fc83249185d65bfe3a2b9d