### PR TITLE
Add startup loader

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import TestPage from './pages/TestPage'
 import AIChatPage from './pages/AIChatPage'
 import AccountPage from './pages/AccountPage'
 import LandingPage from './pages/LandingPage'
-import LoadingVideo from './components/LoadingVideo'
+import StartupLoader from './components/StartupLoader'
 import { useTelegramUser } from './hooks/useTelegramUser'
 import { syncTelegramProfile } from './services/syncTelegramProfile'
 
@@ -21,11 +21,11 @@ const navItems: NavigationItem[] = [
 
 function App() {
   const telegramUser = useTelegramUser()
-  const [loading, setLoading] = useState(true)
+  const [loadingFinished, setLoadingFinished] = useState(false)
 
   useEffect(() => {
     if (localStorage.getItem('intro_seen') === '1') {
-      setLoading(false)
+      setLoadingFinished(true)
     }
   }, [])
 
@@ -40,11 +40,11 @@ function App() {
 
   const handleIntroFinish = () => {
     localStorage.setItem('intro_seen', '1')
-    setLoading(false)
+    setLoadingFinished(true)
   }
 
-  if (loading) {
-    return <LoadingVideo onFinish={handleIntroFinish} />
+  if (!loadingFinished) {
+    return <StartupLoader onFinish={handleIntroFinish} />
   }
 
   return (

--- a/src/components/StartupLoader.tsx
+++ b/src/components/StartupLoader.tsx
@@ -1,0 +1,52 @@
+import { FC, useEffect, useRef, useState } from 'react';
+
+interface StartupLoaderProps {
+  onFinish: () => void;
+}
+
+const StartupLoader: FC<StartupLoaderProps> = ({ onFinish }) => {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const [hidden, setHidden] = useState(false);
+
+  useEffect(() => {
+    const video = videoRef.current;
+    if (video) {
+      video.play().catch((e) => console.warn('❌ Видео не проигрывается:', e));
+      const handleEnded = () => {
+        setHidden(true);
+        onFinish();
+      };
+      video.addEventListener('ended', handleEnded);
+      return () => {
+        video.removeEventListener('ended', handleEnded);
+      };
+    }
+  }, [onFinish]);
+
+  if (hidden) return null;
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        width: '100vw',
+        height: '100vh',
+        backgroundColor: 'black',
+        zIndex: 9999,
+      }}
+    >
+      <video
+        ref={videoRef}
+        src="/start-loading.mp4"
+        style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+        autoPlay
+        muted
+        playsInline
+      />
+    </div>
+  );
+};
+
+export default StartupLoader;


### PR DESCRIPTION
## Summary
- implement `StartupLoader` component
- show loader in `App` when intro not seen

## Testing
- `npm test`
- `npm run lint` *(fails: Strings must use singlequote)*

------
https://chatgpt.com/codex/tasks/task_e_687f8c9bc2688324b6031231c0849422