### PR TITLE
Fix supabase upsert options

### DIFF
--- a/src/services/progressService.ts
+++ b/src/services/progressService.ts
@@ -86,7 +86,7 @@ export async function saveProgress({
           } as any
         ],
         {
-          onConflict: ['user_id', 'section_id']
+          onConflict: 'user_id, section_id'
         }
       )
 


### PR DESCRIPTION
## Summary
- fix supabase `upsert` option to use string argument

## Testing
- `npm test`
- `npm run -s test:ui` *(fails: HTMLMediaElement.play not implemented)*
- `npm run -s build`


------
https://chatgpt.com/codex/tasks/task_e_687fa56d608083249de89f326cc7720f