### PR TITLE
Refactor progress hook with React Query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@apollo/client": "^3.13.8",
         "@supabase/supabase-js": "^2.50.3",
+        "@tanstack/react-query": "^5.83.0",
         "clsx": "^2.1.1",
         "concurrently": "^8.2.2",
         "dotenv": "^16.3.1",
@@ -1743,6 +1744,32 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.83.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.83.0.tgz",
+      "integrity": "sha512-0M8dA+amXUkyz5cVUm/B+zSk3xkQAcuXuz5/Q/LveT4ots2rBpPTZOzd7yJa2Utsf8D2Upl5KyjhHRY+9lB/XA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.83.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.83.0.tgz",
+      "integrity": "sha512-/XGYhZ3foc5H0VM2jLSD/NyBRIOK4q9kfeml4+0x2DlL6xVuAcVEW+hTlTapAmejObg0i3eNqhkr2dT+eciwoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.83.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@telegraf/types": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@apollo/client": "^3.13.8",
     "@supabase/supabase-js": "^2.50.3",
+    "@tanstack/react-query": "^5.83.0",
     "clsx": "^2.1.1",
     "concurrently": "^8.2.2",
     "dotenv": "^16.3.1",
@@ -38,6 +39,7 @@
     "@eslint/config-array": "latest",
     "@eslint/js": "^8.57.1",
     "@eslint/object-schema": "latest",
+    "@tailwindcss/typography": "^0.5.16",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
@@ -56,7 +58,6 @@
     "postcss": "^8.4.32",
     "rimraf": "^4.4.1",
     "tailwindcss": "^3.3.6",
-    "@tailwindcss/typography": "^0.5.16",
     "typescript": "~5.6.2",
     "typescript-eslint": "^7.0.0",
     "vite": "^7.0.5",
@@ -66,6 +67,8 @@
     "node": ">=20"
   },
   "eslintConfig": {
-    "extends": ["eslint:recommended"]
+    "extends": [
+      "eslint:recommended"
+    ]
   }
 }

--- a/src/hooks/useUserProgress.ts
+++ b/src/hooks/useUserProgress.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { useQuery } from '@tanstack/react-query'
 import { supabase } from '../services/supabaseClient'
 import { findOrCreateUserProfile } from '../services/authService'
 import { getTelegramUser } from '../utils/telegram'
@@ -13,15 +14,6 @@ export interface ChapterProgress {
 
 export const useUserProgress = (userId?: string | null) => {
   const [resolvedId, setResolvedId] = useState<string | null>(null)
-  const [progressLoading, setProgressLoading] = useState(true)
-  const [startDate, setStartDate] = useState<string | null>(null)
-  const [completedChapters, setCompletedChapters] = useState(0)
-  const [totalStudyMinutes, setTotalStudyMinutes] = useState(0)
-  const [averageAccuracy, setAverageAccuracy] = useState(0)
-  const [chapterProgress, setChapterProgress] = useState<ChapterProgress[]>([])
-  const [recommendedChapter, setRecommendedChapter] = useState<{chapterId:number; title:string} | null>(null)
-  const [progressData, setProgressData] = useState<any[]>([])
-  const [sectionProgressMap, setSectionProgressMap] = useState<Record<number, { accuracy: number; completed: boolean }>>({})
 
   useEffect(() => {
     const resolve = async () => {
@@ -45,210 +37,59 @@ export const useUserProgress = (userId?: string | null) => {
     void resolve()
   }, [userId])
 
-  useEffect(() => {
-    const fetchStart = async () => {
-      if (!resolvedId) return
-      const { data, error } = await supabase
-        .from('user_progress')
-        .select('answered_at')
-        .eq('user_id', resolvedId)
-        .order('answered_at', { ascending: true })
-        .limit(1)
-        .maybeSingle()
+  const { data, isLoading } = useQuery(
+    ['user-progress', resolvedId],
+    async () => {
+      if (!resolvedId) return null
+      const [progressRes, chaptersRes] = await Promise.all([
+        supabase
+          .from('user_progress')
+          .select(
+            'chapter_id, section_id, question_id, is_correct, time_spent, answered_at, completed, accuracy'
+          )
+          .eq('user_id', resolvedId),
+        supabase.from('chapters').select('id, title, sections(id)')
+      ])
 
-      if (!error) {
-        setStartDate(data?.answered_at ?? null)
-      }
-    }
-    fetchStart()
-  }, [resolvedId])
+      if (progressRes.error) throw progressRes.error
+      if (chaptersRes.error) throw chaptersRes.error
 
-  useEffect(() => {
-    const fetchActualProgress = async () => {
-      setProgressLoading(true)
-      if (!resolvedId) {
-        setProgressLoading(false)
-        return
-      }
+      const progress = progressRes.data || []
+      const chapters = chaptersRes.data || []
 
-      console.log('📊 Запрос расчета прогресса для', resolvedId)
-      const { data: progress, error } = await supabase
-        .from('user_progress')
-        .select('chapter_id, section_id, is_correct, time_spent, answered_at')
-        .eq('user_id', resolvedId)
-
-      if (error) {
-        console.log('❌ Ошибка загрузки прогресса:', error)
-      }
-      if (progress) {
-        console.log('📥 Получены данные для расчета:', progress)
-        if (progress.length === 0) {
-          console.log('❗ Прогресс не найден')
-        }
-      }
-
-      if (error || !progress) {
-        if (error) console.error('Ошибка загрузки прогресса:', error)
-        setProgressLoading(false)
-        return
-      }
-
-      let correctAnswers = 0
-      const sectionMap = new Map<string, { correct: number; total: number; chapter: number }>()
       let firstDate: Date | null = null
+      let correctAnswers = 0
+      const completedPerChapter: Record<number, Set<number>> = {}
+      const sectionProgressMap: Record<number, { accuracy: number; completed: boolean }> = {}
 
-      progress.forEach((row: any) => {
+      progress.forEach(row => {
         if (row.is_correct) correctAnswers += 1
-
-        const key = `${row.chapter_id}-${row.section_id}`
-        if (!sectionMap.has(key)) {
-          sectionMap.set(key, { correct: 0, total: 0, chapter: row.chapter_id })
-        }
-        const stat = sectionMap.get(key)!
-        stat.total += 1
-        if (row.is_correct) stat.correct += 1
-
         if (row.answered_at) {
-          const d = new Date(row.answered_at)
+          const d = new Date(row.answered_at as string)
           if (!firstDate || d < firstDate) firstDate = d
         }
-      })
-
-      const avgAccuracy = progress.length
-        ? Math.round((correctAnswers / progress.length) * 100)
-        : 0
-
-      const { data: sections, error: sectionsError } = await supabase
-        .from('sections')
-        .select('id, chapter_id')
-
-      if (sectionsError) {
-        console.error('Ошибка загрузки списка разделов:', sectionsError)
-        setProgressLoading(false)
-        return
-      }
-
-      const sectionsPerChapter = new Map<number, number>()
-      sections?.forEach((s: any) => {
-        sectionsPerChapter.set(
-          s.chapter_id,
-          (sectionsPerChapter.get(s.chapter_id) || 0) + 1
-        )
-      })
-
-      const chapterAcc: Record<number, number[]> = {}
-      sectionMap.forEach(val => {
-        const acc = val.total ? val.correct / val.total : 0
-        if (!chapterAcc[val.chapter]) chapterAcc[val.chapter] = []
-        chapterAcc[val.chapter].push(acc)
-      })
-
-      let completed = 0
-      for (const [chapterId, total] of sectionsPerChapter) {
-        const arr = chapterAcc[chapterId] || []
-        if (arr.length === total && arr.every(a => a >= 0.7)) {
-          completed += 1
+        if (row.section_id && !row.question_id) {
+          sectionProgressMap[row.section_id] = {
+            accuracy: row.accuracy ?? 0,
+            completed: row.completed ?? false
+          }
         }
-      }
-
-      setCompletedChapters(completed)
-      setAverageAccuracy(avgAccuracy)
-      setStartDate(firstDate ? (firstDate as Date).toISOString() : null)
-      setProgressLoading(false)
-    }
-
-    fetchActualProgress()
-  }, [resolvedId])
-
-  useEffect(() => {
-    const fetchProgress = async () => {
-      if (!resolvedId) return
-      console.log('🔄 Запрос прогресса для userId:', resolvedId)
-      const { data, error } = await supabase
-        .from('user_progress')
-        .select('*')
-        .eq('user_id', resolvedId)
-      if (error) {
-        console.log('❌ Ошибка загрузки прогресса:', error)
-      }
-      if (data) {
-        console.log('📥 Результат user_progress:', data)
-        if (data.length === 0) {
-          console.log('❗ Прогресс не найден')
+        if (row.completed) {
+          if (!completedPerChapter[row.chapter_id]) {
+            completedPerChapter[row.chapter_id] = new Set()
+          }
+          completedPerChapter[row.chapter_id].add(row.section_id)
         }
-        setProgressData(data as any[])
-        const totalTime = data.reduce(
-          (sum: number, p: any) => sum + (p.time_spent || 0),
-          0
-        )
-        setTotalStudyMinutes(Math.floor(totalTime / 60))
-      }
-    }
-    fetchProgress()
-  }, [resolvedId])
-
-  useEffect(() => {
-    const map: Record<number, { accuracy: number; completed: boolean }> = {}
-    progressData.forEach((row: any) => {
-      if (row.section_id && !row.question_id) {
-        map[row.section_id] = {
-          accuracy: row.accuracy ?? 0,
-          completed: row.completed ?? false
-        }
-      }
-    })
-    setSectionProgressMap(map)
-  }, [progressData])
-
-  useEffect(() => {
-    if (progressData.length > 0) {
-      const totalTime = progressData.reduce(
-        (sum: number, p: any) => sum + (p.time_spent || 0),
-        0
-      )
-      setTotalStudyMinutes(Math.floor(totalTime / 60))
-    }
-  }, [progressData])
-
-  useEffect(() => {
-    const fetchChapterProgress = async () => {
-      if (!resolvedId) return
-
-      const { data: chapters } = await supabase
-        .from('chapters')
-        .select('id, title')
-
-      const { data: sections } = await supabase
-        .from('sections')
-        .select('id, chapter_id')
-
-      if (!chapters) return
-
-      const { data: completed } = await supabase
-        .from('user_progress')
-        .select('chapter_id, section_id')
-        .eq('user_id', resolvedId)
-        .eq('completed', true)
+      })
 
       const sectionsByChapter = new Map<number, number>()
-      sections?.forEach((s: any) => {
-        sectionsByChapter.set(
-          s.chapter_id,
-          (sectionsByChapter.get(s.chapter_id) || 0) + 1
-        )
+      chapters.forEach(ch => {
+        sectionsByChapter.set(ch.id, ch.sections ? ch.sections.length : 0)
       })
 
-      const completedMap: Record<number, Set<number>> = {}
-      completed?.forEach((c: any) => {
-        if (!completedMap[c.chapter_id]) {
-          completedMap[c.chapter_id] = new Set()
-        }
-        completedMap[c.chapter_id].add(c.section_id)
-      })
-
-      const result = chapters.map((ch: any) => {
+      const chapterProgress: ChapterProgress[] = chapters.map(ch => {
         const total = sectionsByChapter.get(ch.id) || 0
-        const done = completedMap[ch.id]?.size || 0
+        const done = completedPerChapter[ch.id]?.size || 0
         const percent = total ? Math.round((done / total) * 100) : 0
         return {
           chapterId: ch.id,
@@ -259,31 +100,39 @@ export const useUserProgress = (userId?: string | null) => {
         }
       })
 
-      setChapterProgress(result)
-    }
+      const completedChapters = chapterProgress.filter(c => c.percent === 100).length
+      const recommended = chapterProgress.find(c => c.percent < 100)
+      const totalTime = progress.reduce((sum, p) => sum + (p.time_spent || 0), 0)
+      const avgAccuracy = progress.length ? Math.round((correctAnswers / progress.length) * 100) : 0
 
-    fetchChapterProgress()
-  }, [resolvedId])
-
-  useEffect(() => {
-    if (chapterProgress && chapterProgress.length > 0) {
-      const next = chapterProgress.find(cp => cp.percent < 100)
-      setRecommendedChapter(
-        next ? { chapterId: next.chapterId, title: next.title } : null
-      )
-    }
-  }, [chapterProgress])
+      return {
+        startDate: firstDate ? firstDate.toISOString() : null,
+        completedChapters,
+        totalStudyMinutes: Math.floor(totalTime / 60),
+        averageAccuracy: avgAccuracy,
+        chapterProgress,
+        recommendedChapter: recommended
+          ? { chapterId: recommended.chapterId, title: recommended.title }
+          : null,
+        progressData: progress,
+        sectionProgressMap
+      }
+    },
+    { enabled: !!resolvedId, staleTime: 60 * 1000 }
+  )
 
   return {
-    progressLoading,
-    startDate,
-    completedChapters,
-    totalStudyMinutes,
-    averageAccuracy,
-    chapterProgress,
-    recommendedChapter,
-    progressData,
-    sectionProgressMap
+    progressLoading: isLoading,
+    ...(data || {
+      startDate: null,
+      completedChapters: 0,
+      totalStudyMinutes: 0,
+      averageAccuracy: 0,
+      chapterProgress: [] as ChapterProgress[],
+      recommendedChapter: null as { chapterId: number; title: string } | null,
+      progressData: [] as any[],
+      sectionProgressMap: {} as Record<number, { accuracy: number; completed: boolean }>
+    })
   }
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import App from './App.tsx';
 import AdminPanelPage from './pages/AdminPanelPage';
 import './index.css';
@@ -9,25 +10,29 @@ import { TelegramWebAppProvider } from './components/TelegramWebAppProvider';
 import TelegramLoginRedirect from './components/TelegramLoginRedirect';
 import { UserProvider } from './context/UserContext';
 
+const queryClient = new QueryClient();
+
 const root = createRoot(document.getElementById('root')!);
 
 root.render(
   <StrictMode>
-    <BrowserRouter>
-      {/* SupabaseAuthProvider should wrap TelegramWebAppProvider so that */}
-      {/* the Telegram provider can access authentication context */}
-      <SupabaseAuthProvider>
-        <TelegramWebAppProvider>
-          <UserProvider>
-            <TelegramLoginRedirect />
-            <Routes>
-              <Route path="/admin-panel" element={<AdminPanelPage />} />
-              <Route path="/*" element={<App />} />
-            </Routes>
-          </UserProvider>
-        </TelegramWebAppProvider>
-      </SupabaseAuthProvider>
-    </BrowserRouter>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        {/* SupabaseAuthProvider should wrap TelegramWebAppProvider so that */}
+        {/* the Telegram provider can access authentication context */}
+        <SupabaseAuthProvider>
+          <TelegramWebAppProvider>
+            <UserProvider>
+              <TelegramLoginRedirect />
+              <Routes>
+                <Route path="/admin-panel" element={<AdminPanelPage />} />
+                <Route path="/*" element={<App />} />
+              </Routes>
+            </UserProvider>
+          </TelegramWebAppProvider>
+        </SupabaseAuthProvider>
+      </BrowserRouter>
+    </QueryClientProvider>
   </StrictMode>
 );
 


### PR DESCRIPTION
## Summary
- use `@tanstack/react-query` for caching Supabase requests
- wrap application in `QueryClientProvider`
- replace old `useUserProgress` effects with single query-based implementation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687facd6dfa883248c457b60df05d8e2