### PR TITLE
Implement Telegram profile initialization

### DIFF
--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -1,29 +1,61 @@
 import { createContext, useContext, useState, useEffect } from 'react';
 import { useTelegramUser } from '../hooks/useTelegramUser';
-import { syncTelegramProfile } from '../services/syncTelegramProfile';
+import { supabase } from '../services/supabaseClient';
 
-export const UserContext = createContext<{ userId: string | null }>({ userId: null });
+export const UserContext = createContext<{ userId: string | null; profile: any | null }>({
+  userId: null,
+  profile: null
+});
 
 export const UserProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const telegramUser = useTelegramUser();
   const [userId, setUserId] = useState<string | null>(null);
+  const [profile, setProfile] = useState<any | null>(null);
 
   useEffect(() => {
     async function fetchOrCreate() {
-      if (telegramUser) {
-        const profile = await syncTelegramProfile(telegramUser);
-        if (profile?.id) {
-          setUserId(profile.id);
-          localStorage.setItem('user_id', profile.id); // optional fallback
-        }
+      const telegramId = telegramUser?.id || localStorage.getItem('telegram_id');
+      if (!telegramId) return;
+
+      let { data, error } = await supabase
+        .from('profiles')
+        .select('*')
+        .eq('telegram_id', telegramId)
+        .single();
+
+      if (error && error.code !== 'PGRST116') {
+        console.error('Ошибка при получении профиля:', error);
+        return;
       }
+
+      if (!data) {
+        const { data: newProfile, error: insertError } = await supabase
+          .from('profiles')
+          .insert([{ telegram_id: telegramId, created_at: new Date().toISOString() }])
+          .select()
+          .single();
+        if (insertError) {
+          console.error('Ошибка создания профиля:', insertError);
+          return;
+        }
+        data = newProfile;
+      }
+
+      setProfile(data);
+      setUserId(data.id);
+      localStorage.setItem('user_id', data.id);
+      localStorage.setItem('telegram_id', String(telegramId));
     }
     fetchOrCreate();
   }, [telegramUser]);
 
-  return <UserContext.Provider value={{ userId }}>{children}</UserContext.Provider>;
+  return <UserContext.Provider value={{ userId, profile }}>{children}</UserContext.Provider>;
 };
 
 export function useUserId() {
   return useContext(UserContext).userId;
+}
+
+export function useUserProfile() {
+  return useContext(UserContext).profile;
 }

--- a/src/pages/MyAccount.tsx
+++ b/src/pages/MyAccount.tsx
@@ -1,9 +1,17 @@
-import { useUserId } from '../context/UserContext';
+import { useUserId, useUserProfile } from '../context/UserContext';
 
 function MyAccount() {
   const userId = useUserId();
+  const profile = useUserProfile();
 
-  return <div>Ваш UUID: {userId}</div>;
+  return (
+    <div>
+      <div>Ваш UUID: {userId}</div>
+      {profile && (
+        <pre>{JSON.stringify(profile, null, 2)}</pre>
+      )}
+    </div>
+  );
 }
 
 export default MyAccount;


### PR DESCRIPTION
## Summary
- fetch profile by Telegram ID on startup
- persist profile in context and expose via `useUserProfile`
- show stored profile on the account page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fafc67abc8324ac1f354de3a7af31