### PR TITLE
Lazy load seldom-used pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,13 @@
 import { Home, FileText, Bot, User } from 'lucide-react'
 import { Routes, Route } from 'react-router-dom'
-import { useEffect, useState } from 'react'
+import { useEffect, useState, lazy, Suspense } from 'react'
 import type { NavigationItem } from './components/NavigationBar'
 import MainLayout from './layout/MainLayout'
 import LearningPage from './pages/LearningPage'
 import TestPage from './pages/TestPage'
-import AIChatPage from './pages/AIChatPage'
 import AccountPage from './pages/AccountPage'
-import LandingPage from './pages/LandingPage'
+const AIChatPage = lazy(() => import('./pages/AIChatPage'))
+const LandingPage = lazy(() => import('./pages/LandingPage'))
 import StartupLoader from './components/StartupLoader'
 
 const navItems: NavigationItem[] = [
@@ -41,9 +41,23 @@ function App() {
       <Routes>
         <Route path="/" element={<LearningPage />} />
         <Route path="/test" element={<TestPage />} />
-        <Route path="/ai" element={<AIChatPage />} />
+        <Route
+          path="/ai"
+          element={
+            <Suspense fallback={<div>Loading...</div>}>
+              <AIChatPage />
+            </Suspense>
+          }
+        />
         <Route path="/account" element={<AccountPage />} />
-        <Route path="/landing" element={<LandingPage />} />
+        <Route
+          path="/landing"
+          element={
+            <Suspense fallback={<div>Loading...</div>}>
+              <LandingPage />
+            </Suspense>
+          }
+        />
       </Routes>
     </MainLayout>
   )

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,9 @@
-import { StrictMode } from 'react';
+import { StrictMode, Suspense, lazy } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import App from './App.tsx';
-import AdminPanelPage from './pages/AdminPanelPage';
+const AdminPanelPage = lazy(() => import('./pages/AdminPanelPage'));
 import './index.css';
 import { SupabaseAuthProvider } from './components/SupabaseAuthProvider';
 import { TelegramWebAppProvider } from './components/TelegramWebAppProvider';
@@ -25,7 +25,14 @@ root.render(
             <UserProvider>
               <TelegramLoginRedirect />
               <Routes>
-                <Route path="/admin-panel" element={<AdminPanelPage />} />
+                <Route
+                  path="/admin-panel"
+                  element={
+                    <Suspense fallback={<div>Loading...</div>}>
+                      <AdminPanelPage />
+                    </Suspense>
+                  }
+                />
                 <Route path="/*" element={<App />} />
               </Routes>
             </UserProvider>


### PR DESCRIPTION
## Summary
- implement React.lazy and Suspense for AdminPanelPage
- lazy load AIChatPage and LandingPage in App

## Testing
- `npm run lint`
- `npm test`
- `npm run test:ui` *(fails: missing env vars)*

------
https://chatgpt.com/codex/tasks/task_e_687fba947fe883248c30351d0d8cffc6