### PR TITLE
Remove Supabase connectivity check at startup

### DIFF
--- a/src/services/supabaseClient.ts
+++ b/src/services/supabaseClient.ts
@@ -33,4 +33,3 @@ export const checkConnection = async (): Promise<boolean> => {
   }
 }
 
-checkConnection()


### PR DESCRIPTION
## Summary
- keep `checkConnection()` utility but do not call it on module load

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687fbb6144788324b1be459da9c4ed8b