### PR TITLE
Add prebuild script for environment setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite --host",
+    "prebuild": "node scripts/prepareEnv.cjs",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",

--- a/scripts/prepareEnv.cjs
+++ b/scripts/prepareEnv.cjs
@@ -1,0 +1,14 @@
+const fs = require('fs');
+const path = require('path');
+
+const envPath = path.resolve(__dirname, '..', '.env');
+const examplePath = path.resolve(__dirname, '..', '.env.example');
+
+if (!fs.existsSync(envPath)) {
+  if (fs.existsSync(examplePath)) {
+    fs.copyFileSync(examplePath, envPath);
+    console.log('ℹ️  .env file was missing, copied from .env.example');
+  } else {
+    console.warn('⚠️  No .env or .env.example file found.');
+  }
+}


### PR DESCRIPTION
## Summary
- add script that ensures `.env` exists by copying from `.env.example`
- call the script automatically before `npm run build`

## Testing
- `npm run lint`
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687fc142fcf48324a2306a5dbff3448a