### PR TITLE
Fix user hooks for null user IDs

### DIFF
--- a/src/hooks/useChapterStats.ts
+++ b/src/hooks/useChapterStats.ts
@@ -11,11 +11,19 @@ export interface ChapterStats {
   progress: number
 }
 
-export const useChapterStats = (userId?: string | null) => {
-  const query = useQuery({
+export interface UseChapterStatsResult {
+  data: ChapterStats | null
+  isLoading: boolean
+  isError: boolean
+}
+
+export const useChapterStats = (userId: string | null): UseChapterStatsResult => {
+  const query = useQuery<ChapterStats>({
     queryKey: ['chapter-stats', userId],
     queryFn: async () => {
-      if (!userId) return null
+      if (!userId) {
+        throw new Error('userId is required')
+      }
       let resolvedId = userId
       if (/^\d+$/.test(String(userId))) {
         const tgUser = getTelegramUser()
@@ -62,7 +70,7 @@ export const useChapterStats = (userId?: string | null) => {
         completedChapters,
         totalChapters: totalCh,
         progress
-      } as ChapterStats
+      }
     },
     enabled: !!userId,
     staleTime: 60 * 1000

--- a/src/hooks/useUserProfile.ts
+++ b/src/hooks/useUserProfile.ts
@@ -8,14 +8,24 @@ export interface UserProfile {
   [key: string]: any
 }
 
-const useUserProfile = (userId?: string | null) => {
-  const { user, profile: authProfile, updateProfile } = useAuth()
-  const resolved = userId || user?.id || localStorage.getItem('user_id') || null
+export interface UseUserProfileResult {
+  userId: string | null
+  data: UserProfile | null
+  isLoading: boolean
+  isError: boolean
+  updateProfile: (updates: Record<string, any>) => Promise<UserProfile | null>
+}
 
-  const query = useQuery({
+const useUserProfile = (userId: string | null): UseUserProfileResult => {
+  const { user, profile: authProfile, updateProfile } = useAuth()
+  const resolved = userId ?? user?.id ?? localStorage.getItem('user_id') ?? null
+
+  const query = useQuery<UserProfile>({
     queryKey: ['user-profile', resolved],
     queryFn: async () => {
-      if (!resolved) return null
+      if (!resolved) {
+        throw new Error('userId is required')
+      }
       let finalId = resolved
       if (/^\d+$/.test(String(resolved))) {
         const tgUser = getTelegramUser()

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -14,3 +14,10 @@ vi.mock('./services/supabaseClient', () => ({
 vi.mock('./components/ui/LogConsole', () => ({
   default: () => null,
 }));
+
+// Mock HTMLMediaElement.play to avoid jsdom errors during tests
+Object.defineProperty(window.HTMLMediaElement.prototype, 'play', {
+  configurable: true,
+  writable: true,
+  value: vi.fn().mockResolvedValue(undefined)
+});


### PR DESCRIPTION
## Summary
- improve useChapterStats to handle `string | null` userId
- update useUserProfile to accept nullable `userId`
- add test helper for HTMLMediaElement.play in setupTests

## Testing
- `npm run lint`
- `npm test`
- `npm run test:ui`


------
https://chatgpt.com/codex/tasks/task_e_687fcda676188324bae8e674d04462f6