### PR TITLE
Fix hooks for nullable user IDs

### DIFF
--- a/src/hooks/useChapterStats.ts
+++ b/src/hooks/useChapterStats.ts
@@ -24,7 +24,7 @@ export const useChapterStats = (userId: string | null): UseChapterStatsResult =>
       if (!userId) {
         throw new Error('userId is required')
       }
-      let resolvedId = userId
+      let resolvedId: string | null = userId
       if (/^\d+$/.test(String(userId))) {
         const tgUser = getTelegramUser()
         resolvedId = await findOrCreateUserProfile(
@@ -33,6 +33,9 @@ export const useChapterStats = (userId: string | null): UseChapterStatsResult =>
           tgUser?.first_name || null,
           tgUser?.last_name || null
         )
+      }
+      if (!resolvedId) {
+        throw new Error('Failed to resolve userId')
       }
 
       const { data: chapters, error } = await supabase

--- a/src/hooks/useUserProfile.ts
+++ b/src/hooks/useUserProfile.ts
@@ -26,7 +26,7 @@ const useUserProfile = (userId: string | null): UseUserProfileResult => {
       if (!resolved) {
         throw new Error('userId is required')
       }
-      let finalId = resolved
+      let finalId: string | null = resolved
       if (/^\d+$/.test(String(resolved))) {
         const tgUser = getTelegramUser()
         finalId = await findOrCreateUserProfile(
@@ -35,6 +35,9 @@ const useUserProfile = (userId: string | null): UseUserProfileResult => {
           tgUser?.first_name || null,
           tgUser?.last_name || null
         )
+      }
+      if (!finalId) {
+        throw new Error('Failed to resolve userId')
       }
       if (authProfile && authProfile.id === finalId) {
         return authProfile as UserProfile


### PR DESCRIPTION
## Summary
- handle possible null from `findOrCreateUserProfile`
- keep queries disabled until `userId` resolved

## Testing
- `npm test`
- `npx tsc -p tsconfig.app.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_687fd4f22f3c8324b7eacce951272930