### PR TITLE
Improve chapter and section cards

### DIFF
--- a/src/components/ChaptersList.tsx
+++ b/src/components/ChaptersList.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, type FC } from 'react';
 import { Play, Lock, Award, Shield, ChevronDown } from 'lucide-react';
+import { motion } from 'framer-motion';
 import { SkeletonCard } from './Skeletons';
 import Toast from './Toast';
 import { fetchChapters, fetchSections } from '../services/courseService'
@@ -269,11 +270,20 @@ const ChaptersList: FC<ChaptersListProps> = ({ onChapterSelect, currentUser = ''
 
       {/* Chapters Grid */}
       <div className="grid gap-4">
-        {filteredChapters.map((chapter) => (
+        {filteredChapters.map((chapter) => {
+          const status = chapter.isLocked && !hasAdminAccess()
+            ? '🔒'
+            : chapter.isCompleted
+              ? '✅'
+              : '🔓'
+          return (
           <div key={chapter.id} className="w-full max-w-sm mx-auto px-4">
             <div
-              className={`bg-white rounded-lg shadow p-3 space-y-2 ${chapter.isLocked && !hasAdminAccess() ? 'opacity-60' : ''}`}
+              className={`relative bg-white rounded-2xl shadow-sm p-3 py-2 space-y-1 ${
+                chapter.isLocked && !hasAdminAccess() ? 'opacity-60' : ''
+              }`}
             >
+              <span className="absolute top-2 right-2 text-sm opacity-70">{status}</span>
               <button
                 type="button"
                 onClick={() => handleToggleChapter(chapter)}
@@ -295,7 +305,11 @@ const ChaptersList: FC<ChaptersListProps> = ({ onChapterSelect, currentUser = ''
               </button>
 
               {openChapterId === chapter.id && (
-                <ul className="mt-2 space-y-1">
+                <motion.ul
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  className="mt-2 space-y-1"
+                >
                   {sectionsByChapter[chapter.id]?.map((section) => (
                     <li
                       key={section.id}
@@ -307,7 +321,7 @@ const ChaptersList: FC<ChaptersListProps> = ({ onChapterSelect, currentUser = ''
                       </span>
                     </li>
                   ))}
-                </ul>
+                </motion.ul>
               )}
 
               <button
@@ -316,27 +330,25 @@ const ChaptersList: FC<ChaptersListProps> = ({ onChapterSelect, currentUser = ''
                   onChapterSelect(chapter.id);
                 }}
                 disabled={chapter.isLocked && !hasAdminAccess()}
-                className={`mt-2 max-w-xs w-full px-3 py-1.5 rounded-lg flex items-center justify-center gap-2 text-sm font-semibold transition-colors duration-200 box-border ${
+                aria-label={
+                  chapter.isLocked && !hasAdminAccess()
+                    ? 'Заблокировано'
+                    : chapter.isStarted
+                      ? 'Продолжить'
+                      : 'Начать'
+                }
+                className={`mt-2 max-w-xs w-full px-3 py-1.5 rounded-lg flex items-center justify-center transition-transform hover:scale-105 box-border ${
                   chapter.isLocked && !hasAdminAccess()
                     ? 'bg-gray-300 text-gray-500 cursor-not-allowed'
                     : 'bg-green-600 text-white shadow hover:bg-green-700'
                 } ${hasAdminAccess() && chapter.isLocked ? 'border-2 border-emerald-400' : ''}`}
               >
                 {chapter.isLocked && !hasAdminAccess() ? (
-                  <>
-                    <Lock className="w-4 h-4" />
-                    <span>Заблокировано</span>
-                  </>
+                  <Lock className="w-5 h-5" />
                 ) : hasAdminAccess() && chapter.isLocked ? (
-                  <>
-                    <Shield className="w-4 h-4" />
-                    <span>Открыть (Админ)</span>
-                  </>
+                  <Shield className="w-5 h-5" />
                 ) : (
-                  <>
-                    <Play className="w-4 h-4" />
-                    <span>{chapter.isStarted ? 'Продолжить' : 'Начать'}</span>
-                  </>
+                  <Play className="w-5 h-5" />
                 )}
               </button>
             </div>

--- a/src/components/SectionCard.tsx
+++ b/src/components/SectionCard.tsx
@@ -1,0 +1,37 @@
+import { FC } from 'react'
+import { Play } from 'lucide-react'
+import ProgressBar from './ui/ProgressBar'
+
+interface SectionCardProps {
+  id: number
+  title: string
+  progress: number
+  locked?: boolean
+  onSelect: () => void
+}
+
+const SectionCard: FC<SectionCardProps> = ({ id, title, progress, locked = false, onSelect }) => {
+  const isCompleted = progress >= 100
+  let status = '🔓'
+  if (locked) status = '🔒'
+  else if (isCompleted) status = '✅'
+
+  return (
+    <button
+      onClick={onSelect}
+      disabled={locked}
+      className="relative w-full rounded-2xl shadow-sm bg-white px-3 py-2 flex items-center justify-between hover:scale-105 transition-transform"
+    >
+      <div className="flex flex-col flex-grow pr-2 gap-y-1 text-left">
+        <span className="text-sm truncate text-emerald-900">
+          {`Раздел ${id} — ${title}`}
+        </span>
+        <ProgressBar percent={progress} />
+      </div>
+      <Play className="w-5 h-5 text-emerald-600" />
+      <span className="absolute top-2 right-2 text-sm opacity-70">{status}</span>
+    </button>
+  )
+}
+
+export default SectionCard

--- a/src/components/SectionsList.tsx
+++ b/src/components/SectionsList.tsx
@@ -1,7 +1,7 @@
 import { type FC } from 'react'
-import clsx from 'clsx'
 import { SkeletonSectionList } from './Skeletons'
-import { CheckCircle2, Book } from 'lucide-react'
+import { Book } from 'lucide-react'
+import SectionCard from './SectionCard'
 import { fetchSections } from '../services/courseService'
 import { useLoadData } from '../hooks/useLoadData'
 import useUserProgress from '../hooks/useUserProgress'
@@ -88,39 +88,13 @@ const SectionsList: FC<SectionsListProps> = ({ chapterId, onSectionSelect, onBac
 
       <div className="space-y-2">
         {sections.map((section) => (
-          <button
+          <SectionCard
             key={section.id}
-            onClick={() => onSectionSelect(section.id)}
-            className="w-full bg-white rounded-lg shadow px-3 py-2 flex items-center justify-between"
-          >
-            <div className="flex flex-col items-start flex-grow pr-2">
-              <span
-                className={clsx(
-                  'text-sm truncate',
-                  section.isCompleted ? 'text-emerald-800 font-semibold' : 'text-emerald-900'
-                )}
-              >
-                {`Раздел ${section.id} — ${section.title}`}
-              </span>
-              <div className="w-full bg-gray-200 h-1 rounded-full mt-1">
-                <div
-                  className={clsx(
-                    'h-1 rounded-full transition-all',
-                    section.progress <= 30
-                      ? 'bg-red-400'
-                      : section.progress < 70
-                        ? 'bg-yellow-400'
-                        : 'bg-green-500'
-                  )}
-                  style={{ width: `${section.progress}%` }}
-                />
-              </div>
-            </div>
-            <span className="flex items-center gap-1 text-sm text-emerald-700">
-              {section.isCompleted && <CheckCircle2 className="w-4 h-4 text-green-600" />}
-              {section.progress}%
-            </span>
-          </button>
+            id={section.id}
+            title={section.title}
+            progress={section.progress}
+            onSelect={() => onSectionSelect(section.id)}
+          />
         ))}
       </div>
 

--- a/src/components/ui/ProgressBar.tsx
+++ b/src/components/ui/ProgressBar.tsx
@@ -6,8 +6,12 @@ interface ProgressBarProps {
   height?: string
 }
 
-const ProgressBar: FC<ProgressBarProps> = ({ percent, color = 'bg-emerald-600', height = 'h-2' }) => (
-  <div className={`w-full bg-gray-200 rounded-full ${height}`}>
+const ProgressBar: FC<ProgressBarProps> = ({
+  percent,
+  color = 'bg-emerald-400/60',
+  height = 'h-2'
+}) => (
+  <div className={`w-full ${height} bg-gray-200/60 rounded-full`}>
     <div
       className={`${color} ${height} rounded-full transition-all duration-300`}
       style={{ width: `${percent}%` }}


### PR DESCRIPTION
## Summary
- add reusable `SectionCard` component
- apply soft style and status icon to chapter cards
- animate section reveal with framer-motion
- redesign section list using `SectionCard`
- tweak default `ProgressBar` appearance

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fdb49dc90832489c8738a348e5083