### PR TITLE
Improve account stats layout

### DIFF
--- a/src/features/account/AccountStats.tsx
+++ b/src/features/account/AccountStats.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react'
-import { Calendar, Trophy, TrendingUp, CheckCircle } from 'lucide-react'
-import ProgressBar from '../../components/ui/ProgressBar'
+import { Clock, Target, BookOpen } from 'lucide-react'
+import { motion } from 'framer-motion'
 
 interface AccountStatsProps {
   averageAccuracy: number
@@ -8,28 +8,37 @@ interface AccountStatsProps {
   completedChapters: number
   totalChapters: number
   startDate: string | null
+  totalTime: number
 }
+const AccountStats: FC<AccountStatsProps> = ({
+  totalTime,
+  averageAccuracy,
+  completedChapters,
+  totalChapters
+}) => {
+  const stats = [
+    { label: 'Время', value: `${Math.round(totalTime / 60)} мин`, Icon: Clock },
+    { label: 'Точность', value: `${averageAccuracy}%`, Icon: Target },
+    { label: 'Главы', value: `${completedChapters}/${totalChapters}`, Icon: BookOpen }
+  ]
 
-const AccountStats: FC<AccountStatsProps> = ({ startDate, averageAccuracy, progress, completedChapters, totalChapters }) => (
-  <div className="mt-2 bg-neutral-100 rounded p-2 text-sm text-gray-600 space-y-1">
-    <div className="flex items-center">
-      <Trophy className="w-4 h-4 mr-1" />
-      <span>Средняя точность: {averageAccuracy}%</span>
+  return (
+    <div className="grid grid-cols-3 gap-2 mt-2">
+      {stats.map(({ label, value, Icon }) => (
+        <motion.div
+          key={label}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.3 }}
+          className="flex flex-col items-center gap-y-1 bg-white rounded-2xl shadow-sm p-4"
+        >
+          <Icon className="w-5 h-5 text-emerald-600" />
+          <p className="text-xs text-gray-500">{label}</p>
+          <p className="text-base font-semibold text-gray-900">{value}</p>
+        </motion.div>
+      ))}
     </div>
-    <div className="flex items-center">
-      <TrendingUp className="w-4 h-4 mr-1" />
-      <span>Общий прогресс: {progress}%</span>
-    </div>
-    <div className="flex items-center">
-      <CheckCircle className="w-4 h-4 mr-1" />
-      <span>Пройдено глав: {completedChapters} из {totalChapters}</span>
-    </div>
-    <div className="flex items-center">
-      <Calendar className="w-4 h-4 mr-1" />
-      <span>Дата начала: {startDate ? new Date(startDate).toLocaleDateString('ru-RU') : '-'}</span>
-    </div>
-    <ProgressBar percent={progress} />
-  </div>
-)
+  )
+}
 
 export default AccountStats

--- a/src/features/account/MyAccount.tsx
+++ b/src/features/account/MyAccount.tsx
@@ -106,6 +106,7 @@ const MyAccount: FC<MyAccountProps> = ({ onBackToHome, onStartChapter }) => {
   const debugCall = localStorage.getItem('saveProgress_called')
   const debugStatus = localStorage.getItem('saveProgress_success')
   const debugError = localStorage.getItem('saveProgress_error')
+  const isDev = import.meta.env.DEV
 
   useEffect(() => {
     setNewUsername(profile?.username || '')
@@ -275,6 +276,7 @@ const MyAccount: FC<MyAccountProps> = ({ onBackToHome, onStartChapter }) => {
               completedChapters={chapterStats.completedChapters}
               totalChapters={chapterStats.totalChapters}
               startDate={startDate}
+              totalTime={progressStats.totalTime}
             />
           )}
         </div>
@@ -289,12 +291,31 @@ const MyAccount: FC<MyAccountProps> = ({ onBackToHome, onStartChapter }) => {
           totalSections={totalSections}
           startDate={startDate}
         />
-        {/* Debug info to check saveProgress() calls */}
-        <div className="text-sm text-emerald-700 mb-4">
-          <p>⏱️ Save Progress: {debugCall || 'не вызывался'}</p>
-          <p>✅ Статус: {debugStatus || 'нет данных'}</p>
-          <p>❌ Ошибка: {debugError || 'ошибок нет'}</p>
+        <div className="mt-4">
+          <h3 className="text-base font-semibold text-gray-900 mb-2">🏆 Достижения</h3>
+          <div className="grid grid-cols-3 gap-2">
+            {[
+              { icon: '✅', label: 'Перфекционист — 100% точности в одной главе' },
+              { icon: '⏳', label: 'Устойчивость — более 30 мин обучения' },
+              { icon: '🎯', label: 'Первая победа — пройден первый раздел' }
+            ].map(a => (
+              <div
+                key={a.label}
+                className="flex flex-col items-center gap-y-1 bg-white rounded-2xl shadow-sm p-4"
+              >
+                <span className="text-xl">{a.icon}</span>
+                <p className="text-xs text-gray-500 text-center">{a.label}</p>
+              </div>
+            ))}
+          </div>
         </div>
+        {isDev && (
+          <div className="text-sm text-emerald-700 mb-4">
+            <p>⏱️ Save Progress: {debugCall || 'не вызывался'}</p>
+            <p>✅ Статус: {debugStatus || 'нет данных'}</p>
+            <p>❌ Ошибка: {debugError || 'ошибок нет'}</p>
+          </div>
+        )}
 
         {achievements && achievements.length > 0 && (
           <div className="bg-white rounded-xl shadow-sm border border-yellow-200 p-6 mb-6">


### PR DESCRIPTION
## Summary
- display save progress debug only in dev mode
- show simple achievements below the stats
- refactor `AccountStats` to card layout with fade-in animation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ffe67b00083248dce93fcf179b2db