### PR TITLE
Implement tab slider transitions

### DIFF
--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -1,56 +1,68 @@
 import { Home, FileText, Bot, User } from 'lucide-react';
-import { NavLink } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import clsx from 'clsx';
 import { BOTTOM_NAV_ITEM_BASE } from '../utils/classNames';
 
-const navItems = [
-  { label: 'Главная', icon: Home, path: '/', animation: { scale: 1.2 } },
-  { label: 'Тест', icon: FileText, path: '/test', animation: { y: -8 } },
-  { label: 'AI', icon: Bot, path: '/ai', animation: { rotate: 20 } },
+export type Tab = 'home' | 'test' | 'ai' | 'profile';
+
+interface BottomNavigationProps {
+  currentTab: Tab;
+  setCurrentTab: (tab: Tab) => void;
+}
+
+const navItems: { label: string; icon: typeof Home; tab: Tab; animation: any }[] = [
+  { label: 'Главная', icon: Home, tab: 'home', animation: { scale: 1.2 } },
+  { label: 'Тест', icon: FileText, tab: 'test', animation: { y: -8 } },
+  { label: 'AI', icon: Bot, tab: 'ai', animation: { rotate: 20 } },
   {
     label: 'Аккаунт',
     icon: User,
-    path: '/account',
-    animation: { boxShadow: '0 0 8px rgb(34 197 94)', backgroundColor: 'rgba(34,197,94,0.2)', borderRadius: '0.375rem' },
+    tab: 'profile',
+    animation: {
+      boxShadow: '0 0 8px rgb(34 197 94)',
+      backgroundColor: 'rgba(34,197,94,0.2)',
+      borderRadius: '0.375rem',
+    },
   },
 ];
 
-const BottomNavigation = () => {
+const BottomNavigation = ({ currentTab, setCurrentTab }: BottomNavigationProps) => {
   return (
     <nav className="fixed bottom-0 left-0 right-0 bg-white shadow-md flex justify-around items-center py-2 z-50">
-      {navItems.map(({ label, icon: Icon, path, animation }) => (
-        <NavLink key={path} to={path} end className={BOTTOM_NAV_ITEM_BASE}>
-          {({ isActive }) => (
-            <motion.div
-              whileTap={animation}
-              transition={{ duration: 0.2 }}
+      {navItems.map(({ label, icon: Icon, tab, animation }) => (
+        <button
+          key={tab}
+          onClick={() => setCurrentTab(tab)}
+          className={BOTTOM_NAV_ITEM_BASE}
+        >
+          <motion.div
+            whileTap={animation}
+            transition={{ duration: 0.2 }}
+            className={clsx(
+              'flex flex-col items-center',
+              currentTab === tab ? 'text-green-600 font-semibold' : 'text-gray-400'
+            )}
+          >
+            <div
               className={clsx(
-                'flex flex-col items-center',
-                isActive ? 'text-green-600 font-semibold' : 'text-gray-400 hover:text-green-600'
+                'p-2 rounded-full transition-all',
+                currentTab === tab
+                  ? 'ring-2 ring-green-500 text-green-600'
+                  : 'text-gray-400'
               )}
             >
-              <div
-                className={clsx(
-                  'p-2 rounded-full transition-all',
-                  isActive
-                    ? 'ring-2 ring-green-500 text-green-600'
-                    : 'text-gray-400 group-hover:text-green-600'
-                )}
-              >
-                <Icon size={20} />
-              </div>
-              <span
-                className={clsx(
-                  'mt-1 transition-colors',
-                  isActive ? 'font-semibold text-green-600' : 'text-gray-400 group-hover:text-green-600'
-                )}
-              >
-                {label}
-              </span>
-            </motion.div>
-          )}
-        </NavLink>
+              <Icon size={20} />
+            </div>
+            <span
+              className={clsx(
+                'mt-1 transition-colors',
+                currentTab === tab ? 'font-semibold text-green-600' : 'text-gray-400'
+              )}
+            >
+              {label}
+            </span>
+          </motion.div>
+        </button>
       ))}
     </nav>
   );

--- a/src/layout/MainLayout.tsx
+++ b/src/layout/MainLayout.tsx
@@ -1,34 +1,15 @@
 import { FC, ReactNode } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { useSwipeable } from 'react-swipeable';
-import NavigationBar, { NavigationItem } from '../components/NavigationBar';
 import LogConsole from '../components/ui/LogConsole';
 
 interface MainLayoutProps {
   children: ReactNode;
-  items: NavigationItem[];
-  showNavigation?: boolean;
 }
 
-const MainLayout: FC<MainLayoutProps> = ({ children, items, showNavigation = true }) => {
-  const navigate = useNavigate();
-  const handlers = useSwipeable({
-    onSwipedRight: (data) => {
-      if (data.initial[0] <= 30 && data.deltaX > 50) {
-        navigate(-1);
-      }
-    },
-    trackTouch: true,
-  });
-
+const MainLayout: FC<MainLayoutProps> = ({ children }) => {
   return (
-    <div
-      {...handlers}
-      className={`min-h-screen bg-gradient-to-br from-emerald-50 to-green-50 ${showNavigation ? 'pb-24' : ''}`}
-    >
+    <div className="min-h-screen bg-gradient-to-br from-emerald-50 to-green-50 pb-24">
       {children}
       <LogConsole />
-      <NavigationBar items={items} show={showNavigation} />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- remove swipe-back NavigationBar layout
- introduce BottomNavigation with state tabs
- switch App to state-based navigation with slide transitions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688018c8d13483248775cc6ece7ea11d