### PR TITLE
Add XP-based chapter unlocks

### DIFF
--- a/src/features/account/MapProgress.tsx
+++ b/src/features/account/MapProgress.tsx
@@ -3,17 +3,31 @@ import { useNavigate } from 'react-router-dom'
 import { motion } from 'framer-motion'
 import clsx from 'clsx'
 import { supabase } from '../../services/supabaseClient'
+import { useAuth } from '../../components/SupabaseAuthProvider'
+import Toast from '../../components/Toast'
 
 interface MapItem {
   id: number
   title: string
   completed: boolean
   locked: boolean
+  justUnlocked?: boolean
+}
+
+const chapterRequirements: Record<number, number> = {
+  1: 0,
+  2: 100,
+  3: 200,
+  4: 300,
+  5: 400
 }
 
 const MapProgress: FC = () => {
   const navigate = useNavigate()
   const [items, setItems] = useState<MapItem[]>([])
+  const [toastMessage, setToastMessage] = useState<string | null>(null)
+  const { stats } = useAuth()
+  const xp = (stats?.completedSections || 0) * 20
 
   useEffect(() => {
     const loadData = async () => {
@@ -43,21 +57,30 @@ const MapProgress: FC = () => {
       })
 
       const all = chaptersRes.data || []
-      const processed: MapItem[] = all.map((ch, idx) => {
-        const completed = progressMap[ch.id] || false
-        const prevCompleted = idx === 0 || progressMap[all[idx - 1].id]
-        return {
-          id: ch.id,
-          title: ch.title || `Глава ${ch.id}`,
-          completed,
-          locked: idx !== 0 && !prevCompleted
-        }
+      setItems(prevItems => {
+        const processed: MapItem[] = all.map((ch, idx) => {
+          const completed = progressMap[ch.id] || false
+          const prevCompleted = idx === 0 || progressMap[all[idx - 1].id]
+          const unlocked = prevCompleted || xp >= (chapterRequirements[ch.id] || 0)
+          const prevItem = prevItems.find(p => p.id === ch.id)
+          const justUnlocked = prevItem ? prevItem.locked && unlocked : false
+          if (justUnlocked) {
+            setToastMessage(`🎉 Глава ${ch.id} разблокирована! Достигнут XP: ${xp}`)
+          }
+          return {
+            id: ch.id,
+            title: ch.title || `Глава ${ch.id}`,
+            completed,
+            locked: !unlocked,
+            justUnlocked
+          }
+        })
+        return processed
       })
-      setItems(processed)
     }
 
     loadData()
-  }, [])
+  }, [xp])
 
   return (
     <div className="relative grid grid-cols-1 sm:grid-cols-3 md:grid-cols-4 gap-6">
@@ -67,9 +90,10 @@ const MapProgress: FC = () => {
             <div className="absolute top-6 -left-1/2 w-full border-t border-gray-300" />
           )}
           <motion.div
-            initial={{ scale: 0 }}
-            animate={{ scale: 1 }}
-            transition={{ delay: index * 0.1 }}
+            key={item.id}
+            initial={item.justUnlocked ? { scale: 0.5, opacity: 0 } : { scale: 0 }}
+            animate={{ scale: item.justUnlocked ? 1.1 : 1, opacity: 1 }}
+            transition={{ delay: index * 0.1, duration: 0.4, ease: 'easeOut' }}
             onClick={item.locked ? undefined : () => navigate(`/chapter/${item.id}`)}
             className={clsx('cursor-pointer', item.locked && 'opacity-50 pointer-events-none')}
           >
@@ -82,9 +106,13 @@ const MapProgress: FC = () => {
               {index + 1}
             </div>
             <p className="text-xs text-center">{item.title}</p>
+            {item.locked && (
+              <p className="text-[10px] text-gray-400">Требуется XP: {chapterRequirements[item.id]}</p>
+            )}
           </motion.div>
         </div>
       ))}
+      {toastMessage && <Toast message={toastMessage} onClose={() => setToastMessage(null)} />}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- tie `MapProgress` to user XP and show toast on unlock
- add glow animation when chapter becomes available

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68801df59e088324b9372e9d1eb9f7c2