### PR TITLE
Switch to manual tab management

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import MainLayout from './layout/MainLayout'
 import LearningPage from './pages/LearningPage'
 import TestPage from './pages/TestPage'
 import AccountPage from './pages/AccountPage'
-import BottomNavigation from './components/BottomNavigation'
+import BottomNav from './components/BottomNavigation'
 const AIChatPage = lazy(() => import('./pages/AIChatPage'))
 import StartupLoader from './components/StartupLoader'
 
@@ -35,7 +35,7 @@ function App() {
     home: <LearningPage />,
     test: <TestPage />,
     ai: (
-      <Suspense fallback={<div>Loading...</div>}>
+      <Suspense fallback={<p className="text-center text-gray-400">Контент загружается...</p>}>
         <AIChatPage />
       </Suspense>
     ),
@@ -50,8 +50,7 @@ function App() {
     ),
   }
 
-  console.log('Текущий экран:', currentTab)
-  console.log('Компонент:', tabs[currentTab])
+  console.log(currentTab, tabs[currentTab])
 
   const changeTab = (tab: Tab) => {
     setCurrentTab(tab)
@@ -59,7 +58,7 @@ function App() {
 
   return (
     <MainLayout>
-      <div className="relative overflow-hidden">
+      <div className="relative overflow-hidden bg-gray-50">
         <AnimatePresence mode="wait">
           <motion.div
             key={currentTab}
@@ -67,12 +66,11 @@ function App() {
             animate={{ x: 0, opacity: 1 }}
             exit={{ x: -50, opacity: 0 }}
             transition={{ duration: 0.2 }}
-            className="absolute inset-0"
           >
-            {tabs[currentTab] ?? <p>Компонент не найден</p>}
+            {tabs[currentTab] ?? <p className="text-center text-red-500 mt-10">Компонент не найден</p>}
           </motion.div>
         </AnimatePresence>
-        <BottomNavigation currentTab={currentTab} setCurrentTab={changeTab} />
+        <BottomNav currentTab={currentTab} setCurrentTab={changeTab} />
       </div>
     </MainLayout>
   )

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -1,18 +1,19 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import App from '../App';
-import { MemoryRouter } from 'react-router-dom';
 
 beforeEach(() => {
   localStorage.setItem('intro_seen', '1');
 });
 
 test('renders navigation labels', () => {
-  render(<MemoryRouter initialEntries={['/ai']}><App /></MemoryRouter>);
+  render(<App />);
   expect(screen.getAllByText(/Главная/i)[0]).toBeInTheDocument();
   expect(screen.getAllByText(/Тест/i)[0]).toBeInTheDocument();
 });
 
-test('renders AI page when routed', () => {
-  render(<MemoryRouter initialEntries={['/ai']}><App /></MemoryRouter>);
-  expect(screen.getAllByText(/AI/i)[0]).toBeInTheDocument();
+test('renders AI page after tab click', async () => {
+  render(<App />);
+  await userEvent.click(screen.getByText(/AI/i));
+  expect(screen.getByText(/AI Помощник/i)).toBeInTheDocument();
 });

--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -26,7 +26,7 @@ const navItems: { label: string; icon: typeof Home; tab: Tab; animation: any }[]
   },
 ];
 
-const BottomNavigation = ({ currentTab, setCurrentTab }: BottomNavigationProps) => {
+const BottomNav = ({ currentTab, setCurrentTab }: BottomNavigationProps) => {
   return (
     <nav className="fixed bottom-0 left-0 right-0 bg-white shadow-md flex justify-around items-center py-2 z-50">
       {navItems.map(({ label, icon: Icon, tab, animation }) => (
@@ -68,4 +68,4 @@ const BottomNavigation = ({ currentTab, setCurrentTab }: BottomNavigationProps) 
   );
 };
 
-export default BottomNavigation;
+export default BottomNav;

--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -1,5 +1,4 @@
 import { FC } from 'react';
-import { NavLink, useLocation } from 'react-router-dom';
 import { LucideIcon } from 'lucide-react';
 import clsx from 'clsx';
 import { NAV_ITEM_BASE, NAV_ICON_BASE } from '../utils/classNames';
@@ -17,8 +16,8 @@ interface NavigationBarProps {
 }
 
 const NavigationBar: FC<NavigationBarProps> = ({ items, show = true }) => {
-  const { pathname } = useLocation();
-  if (!show) return null;
+  const pathname = window.location.pathname;
+  if (!show) return <p className="text-center text-gray-400">Контент загружается...</p>;
   return (
     <nav className="fixed bottom-0 left-0 right-0 bg-white border-t border-emerald-200 shadow-lg z-50 safe-area-inset-bottom">
       <div className="max-w-md mx-auto">
@@ -26,10 +25,9 @@ const NavigationBar: FC<NavigationBarProps> = ({ items, show = true }) => {
           {items.map(({ id, label, icon: Icon, path }) => {
             const active = pathname === path;
             return (
-              <NavLink
+              <a
                 key={id}
-                to={path}
-                end
+                href={path}
                 className={clsx(
                   NAV_ITEM_BASE,
                   active
@@ -41,7 +39,7 @@ const NavigationBar: FC<NavigationBarProps> = ({ items, show = true }) => {
               <span className="text-xs font-medium transition-all duration-200 text-center leading-tight">
                 {label}
               </span>
-              </NavLink>
+              </a>
             );
           })}
         </div>

--- a/src/components/SectionComplete.tsx
+++ b/src/components/SectionComplete.tsx
@@ -110,7 +110,7 @@ const SectionComplete: FC<SectionCompleteProps> = ({
     );
   }
 
-  return null;
+  return <p className="text-center text-gray-400">Контент загружается...</p>;
 };
 
 export default SectionComplete;

--- a/src/components/StartupLoader.tsx
+++ b/src/components/StartupLoader.tsx
@@ -23,7 +23,7 @@ const StartupLoader: FC<StartupLoaderProps> = ({ onFinish }) => {
     }
   }, [onFinish]);
 
-  if (hidden) return null;
+  if (hidden) return <p className="text-center text-gray-400">Контент загружается...</p>;
 
   return (
     <div

--- a/src/components/TelegramLoginRedirect.tsx
+++ b/src/components/TelegramLoginRedirect.tsx
@@ -1,15 +1,13 @@
 import { useEffect, useState, useRef } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { useAuth } from './SupabaseAuthProvider';
 import { findOrCreateUserProfile } from '../services/authService';
 import { getTelegramUser } from '../utils/telegram';
 import LoadingScreen from './LoadingScreen';
 
 const TelegramLoginRedirect = () => {
-  const navigate = useNavigate();
   const [loading, setLoading] = useState(true);
   const { profile, loading: authLoading } = useAuth();
-  const navigateRef = useRef(false);
+  const processedRef = useRef(false);
 
   useEffect(() => {
     window.Telegram?.WebApp?.ready();
@@ -40,26 +38,25 @@ const TelegramLoginRedirect = () => {
     };
 
     initProfile();
-  }, [navigate]);
+  }, []);
 
   useEffect(() => {
     if (
-      !navigateRef.current &&
+      !processedRef.current &&
       profile &&
       !authLoading &&
       localStorage.getItem('user_id')
     ) {
-      console.log('Navigate to /account', {
+      console.log('Profile ready', {
         telegramUser: getTelegramUser(),
         user_id: localStorage.getItem('user_id'),
         profile
       });
-      navigateRef.current = true;
-      navigate('/account');
+      processedRef.current = true;
     }
-  }, [profile, authLoading, navigate]);
+  }, [profile, authLoading]);
 
-  if (!loading) return null;
+  if (!loading) return <p className="text-center text-gray-400">Контент загружается...</p>;
 
   return (
     <LoadingScreen />

--- a/src/pages/LearningPage.tsx
+++ b/src/pages/LearningPage.tsx
@@ -66,7 +66,7 @@ const LearningPage = () => {
         />
       );
     default:
-      return null;
+      return <p className="text-center text-gray-400">Контент загружается...</p>;
   }
 };
 

--- a/src/pages/TestPage.tsx
+++ b/src/pages/TestPage.tsx
@@ -49,7 +49,7 @@ const TestPage = () => {
     case 'results':
       return <TestResults results={testResults!} onSaveResults={() => {}} onRetakeTest={handleRetakeTest} />;
     default:
-      return null;
+      return <p className="text-center text-gray-400">Контент загружается...</p>;
   }
 };
 


### PR DESCRIPTION
## Summary
- drop react-router usage
- add BottomNav for tab switching
- replace early `null` returns with loading placeholders
- update tests for new navigation logic

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688025fc6a908324b87db2389fcb7d47