### PR TITLE
Add achievements progress in profile

### DIFF
--- a/src/components/SectionComplete.tsx
+++ b/src/components/SectionComplete.tsx
@@ -7,6 +7,7 @@ import SectionFailed from './SectionFailed';
 import SectionSuccess from './SectionSuccess';
 import { getNextStep } from '../utils/navigation.js';
 import Toast from './Toast';
+import { ACHIEVEMENTS } from '../features/account/Achievements';
 
 interface SectionResults {
   totalQuestions: number;
@@ -19,6 +20,7 @@ interface SectionCompleteProps {
   results: SectionResults;
   chapterId: number;
   sectionId: number;
+  newAchievements?: string[];
   onRetry?: () => void;
   onNext?: (nextSectionId?: string, nextChapterId?: string) => void;
 }
@@ -27,6 +29,7 @@ const SectionComplete: FC<SectionCompleteProps> = ({
   results,
   chapterId,
   sectionId,
+  newAchievements,
   onRetry,
   onNext
 }) => {
@@ -38,6 +41,22 @@ const SectionComplete: FC<SectionCompleteProps> = ({
   const [nextSectionId, setNextSectionId] = useState<string | undefined>(undefined);
   const [nextChapterId, setNextChapterId] = useState<string | undefined>(undefined);
   const [toastMessage, setToastMessage] = useState<string | null>(null);
+  const [achQueue, setAchQueue] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (newAchievements && newAchievements.length > 0) {
+      setAchQueue(newAchievements);
+    }
+  }, [newAchievements]);
+
+  useEffect(() => {
+    if (!toastMessage && achQueue.length > 0) {
+      const type = achQueue[0];
+      const title = ACHIEVEMENTS.find(a => a.type === type)?.title || type;
+      setToastMessage(`🏆 Новое достижение: ${title}!`);
+      setAchQueue(q => q.slice(1));
+    }
+  }, [toastMessage, achQueue]);
 
   useEffect(() => {
     getNextStep(sectionId).then(step => {
@@ -81,6 +100,9 @@ const SectionComplete: FC<SectionCompleteProps> = ({
         try {
           await refreshStats();
           setToastMessage('🎉 Раздел пройден! Вы получили +20 XP');
+          if (newAchievements && newAchievements.length > 0) {
+            setAchQueue(newAchievements);
+          }
         } catch (err) {
           console.error('Ошибка обновления статистики:', err);
         }

--- a/src/features/account/Achievements.tsx
+++ b/src/features/account/Achievements.tsx
@@ -1,4 +1,6 @@
 import { FC } from 'react'
+import { motion } from 'framer-motion'
+import clsx from 'clsx'
 
 export interface Achievement {
   title: string
@@ -18,17 +20,25 @@ interface AchievementsProps {
 }
 
 const Achievements: FC<AchievementsProps> = ({ completed = [] }) => (
-  <div className="grid grid-cols-3 gap-2">
-    {ACHIEVEMENTS.map(a => {
-      const done = completed.includes(a.type)
+  <div className="grid grid-cols-2 gap-3 mt-6">
+    {ACHIEVEMENTS.map((a, i) => {
+      const unlocked = completed.includes(a.type)
       return (
-        <div
+        <motion.div
           key={a.type}
-          className={`flex flex-col items-center gap-y-1 bg-white rounded-2xl shadow-sm p-4 ${done ? '' : 'opacity-50'}`}
+          initial={{ opacity: 0, y: 5 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: i * 0.1 }}
+          className={clsx(
+            'p-3 rounded-xl border text-sm transition',
+            unlocked
+              ? 'bg-white text-emerald-700 border-emerald-300 shadow-sm'
+              : 'bg-gray-100 text-gray-400 border-gray-200'
+          )}
         >
-          <span className="text-xl">{a.icon}</span>
-          <p className="text-xs text-center text-gray-500">{a.title}</p>
-        </div>
+          <p className="font-semibold">{a.title}</p>
+          <p className="text-xs">{a.condition}</p>
+        </motion.div>
       )
     })}
   </div>

--- a/src/features/account/MyAccount.tsx
+++ b/src/features/account/MyAccount.tsx
@@ -178,9 +178,8 @@ const MyAccount: FC<MyAccountProps> = ({ onBackToHome, onStartChapter }) => {
   const totalSections = chapterProgress.reduce((sum, cp) => sum + cp.totalSections, 0)
   const completedSections = chapterProgress.reduce((sum, cp) => sum + cp.completedSections, 0)
   const xp = progressStats.completedSections * 20
-  const nextLevelXp = 200
-  const level = xp < nextLevelXp ? 'A1' : 'A2'
-  const xpPercent = Math.min(((xp % nextLevelXp) / nextLevelXp) * 100, 100)
+  const level = Math.floor(xp / 100)
+  const progress = xp % 100
 
   if (loading || statsLoading) {
     return (
@@ -275,13 +274,14 @@ const MyAccount: FC<MyAccountProps> = ({ onBackToHome, onStartChapter }) => {
       </div>
       <div className="p-6">
         <div className="mb-4">
-          <div className="flex justify-between items-center text-sm font-medium mb-1">
-            <span>Уровень: {level}</span>
-            <span>XP: {xp} / {nextLevelXp}</span>
+          <p className="text-sm text-gray-500">Уровень: {level}</p>
+          <div className="w-full h-2 rounded-full bg-gray-200 mt-1">
+            <div
+              className="h-2 rounded-full bg-emerald-500"
+              style={{ width: `${progress}%` }}
+            />
           </div>
-          <div className="h-2 rounded-full bg-gray-200 overflow-hidden">
-            <div className="h-2 bg-emerald-500 rounded-full" style={{ width: `${xpPercent}%` }} />
-          </div>
+          <p className="text-xs text-gray-400 mt-1">{xp} XP</p>
         </div>
         <StatsCarousel
           totalTime={progressStats.totalTime}

--- a/src/hooks/useLearningNavigation.ts
+++ b/src/hooks/useLearningNavigation.ts
@@ -19,6 +19,7 @@ export function useLearningNavigation() {
   const [selectedSection, setSelectedSection] = useState<number | null>(null)
   const [sectionResults, setSectionResults] = useState<QuestionResults | null>(null)
   const [sectionStartTime, setSectionStartTime] = useState<number | null>(null)
+  const [earnedAchievements, setEarnedAchievements] = useState<string[]>([])
 
   const { profile, refreshStats } = useAuth()
 
@@ -94,13 +95,14 @@ export function useLearningNavigation() {
           results.totalQuestions,
           timeSpent
         )
-        await saveTestResults(
+        const { achievements } = await saveTestResults(
           selectedChapter,
           selectedSection,
           results.correctAnswers,
           results.totalQuestions,
           timeSpent
         )
+        setEarnedAchievements(achievements)
         await refreshStats()
       } catch (err) {
         console.error('Ошибка сохранения результатов раздела:', err)
@@ -155,6 +157,7 @@ export function useLearningNavigation() {
     selectedChapter,
     selectedSection,
     sectionResults,
+    earnedAchievements,
     profile,
     handleChapterSelect,
     handleSectionSelect,

--- a/src/pages/LearningPage.tsx
+++ b/src/pages/LearningPage.tsx
@@ -11,6 +11,7 @@ const LearningPage = () => {
     selectedChapter,
     selectedSection,
     sectionResults,
+    earnedAchievements,
     profile,
     handleChapterSelect,
     handleSectionSelect,
@@ -53,6 +54,7 @@ const LearningPage = () => {
           results={sectionResults!}
           chapterId={selectedChapter!}
           sectionId={selectedSection!}
+          newAchievements={earnedAchievements}
           onRetry={handleRetrySection}
           onNext={handleNextStep}
         />


### PR DESCRIPTION
## Summary
- show numeric level and progress bar on profile page
- redesign Achievements grid with animation
- queue achievement toasts on section completion
- surface new achievements via learning navigation

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68802d850f9883249a069faadddc3fed