### PR TITLE
Implement grey dashed zigzag path

### DIFF
--- a/src/components/ui/ZigZagPath.tsx
+++ b/src/components/ui/ZigZagPath.tsx
@@ -1,6 +1,5 @@
 import { FC } from 'react'
 import { motion } from 'framer-motion'
-import clsx from 'clsx'
 
 interface ZigZagPathProps {
   d: string
@@ -20,11 +19,12 @@ const pathVariants = {
 const ZigZagPath: FC<ZigZagPathProps> = ({ d, index, className }) => (
   <motion.path
     d={d}
-    strokeWidth="2"
-    strokeDasharray="4 4"
+    strokeWidth="1.5"
+    strokeDasharray="4"
     strokeLinecap="round"
+    stroke="#C5C5C5"
     fill="none"
-    className={clsx('stroke-emerald-600', className)}
+    className={className}
     initial="hidden"
     animate="visible"
     variants={pathVariants}


### PR DESCRIPTION
## Summary
- tweak `ZigZagPath` connector to match grey dashed style

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6880f1a7b8c08324bfc175fac585d5f0