### PR TITLE
Centralize chapter title helper

### DIFF
--- a/src/components/ChaptersAndSections.tsx
+++ b/src/components/ChaptersAndSections.tsx
@@ -3,6 +3,7 @@ import { fetchChapters, fetchSections } from '../services/courseService';
 import { useAuth } from './SupabaseAuthProvider';
 import useUserProgress from '../hooks/useUserProgress';
 import SectionsList from './SectionsList';
+import { getChapterTitle } from '../utils/courseTitles';
 
 interface ChaptersAndSectionsProps {
   onSectionSelect: (chapterId: number, sectionId: number) => void;
@@ -21,35 +22,6 @@ interface ChapterData {
   title: string;
   sections: SectionInfo[];
 }
-
-const getChapterTitle = (chapterId: number): string => {
-  switch (chapterId) {
-    case 1:
-      return 'Основы эсперанто';
-    case 2:
-      return 'Основные глаголы и действия';
-    case 3:
-      return 'Грамматика';
-    case 4:
-      return 'Словарный запас';
-    case 5:
-      return 'Произношение';
-    case 6:
-      return 'Диалоги';
-    case 7:
-      return 'Культура';
-    case 8:
-      return 'Литература';
-    case 9:
-      return 'История языка';
-    case 10:
-      return 'Практические упражнения';
-    case 11:
-      return 'Итоговый тест';
-    default:
-      return `Глава ${chapterId}`;
-  }
-};
 
 const ChaptersAndSections: FC<ChaptersAndSectionsProps> = ({ onSectionSelect }) => {
   const { profile } = useAuth();

--- a/src/components/QuestionInterface.tsx
+++ b/src/components/QuestionInterface.tsx
@@ -8,6 +8,7 @@ import { saveProgressBulk, saveTestResults } from '../services/progressService'
 import { useAuth } from './SupabaseAuthProvider'
 import { useLoadData } from '../hooks/useLoadData';
 import TheoryBlock from './TheoryBlock';
+import { getChapterTitle } from '../utils/courseTitles';
 
 
 export interface QuestionResultItem {
@@ -96,14 +97,6 @@ const QuestionInterface: FC<QuestionInterfaceProps> = ({
     return <div className="p-6">Данные не найдены</div>
   }
 
-  const getChapterTitle = (chapterId: number): string => {
-    switch (chapterId) {
-      case 1: return "Основы эсперанто";
-      case 2: return "Основные глаголы и действия";
-      case 3: return "Грамматика";
-      default: return `Глава ${chapterId}`;
-    }
-  };
 
   const getSectionTitle = (chapterId: number, sectionId: number): string => {
     if (chapterId === 1) {

--- a/src/components/SectionsList.tsx
+++ b/src/components/SectionsList.tsx
@@ -2,6 +2,7 @@ import { FC } from 'react'
 import clsx from 'clsx'
 import { motion } from 'framer-motion'
 import ZigZagPath from './ui/ZigZagPath'
+import { getChapterTitle } from '../utils/courseTitles'
 
 interface SectionInfo {
   id: number
@@ -15,35 +16,6 @@ interface SectionsListProps {
   chapterId: number
   sections: SectionInfo[]
   onSectionSelect: (sectionId: number) => void
-}
-
-const getChapterTitle = (chapterId: number): string => {
-  switch (chapterId) {
-    case 1:
-      return 'Основы эсперанто'
-    case 2:
-      return 'Основные глаголы и действия'
-    case 3:
-      return 'Грамматика'
-    case 4:
-      return 'Словарный запас'
-    case 5:
-      return 'Произношение'
-    case 6:
-      return 'Диалоги'
-    case 7:
-      return 'Культура'
-    case 8:
-      return 'Литература'
-    case 9:
-      return 'История языка'
-    case 10:
-      return 'Практические упражнения'
-    case 11:
-      return 'Итоговый тест'
-    default:
-      return `Глава ${chapterId}`
-  }
 }
 
 const circleVariants = {

--- a/src/utils/courseTitles.ts
+++ b/src/utils/courseTitles.ts
@@ -1,0 +1,28 @@
+export function getChapterTitle(id: number): string {
+  switch (id) {
+    case 1:
+      return 'Основы эсперанто';
+    case 2:
+      return 'Основные глаголы и действия';
+    case 3:
+      return 'Грамматика';
+    case 4:
+      return 'Словарный запас';
+    case 5:
+      return 'Произношение';
+    case 6:
+      return 'Диалоги';
+    case 7:
+      return 'Культура';
+    case 8:
+      return 'Литература';
+    case 9:
+      return 'История языка';
+    case 10:
+      return 'Практические упражнения';
+    case 11:
+      return 'Итоговый тест';
+    default:
+      return `Глава ${id}`;
+  }
+}


### PR DESCRIPTION
## Summary
- add `getChapterTitle` helper under `src/utils/courseTitles.ts`
- replace duplicated implementations in `ChaptersAndSections`, `SectionsList` and `QuestionInterface`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6880f8cd5698832496c055e5f6d2172c