### PR TITLE
Refine chapter button appearance

### DIFF
--- a/src/components/ChapterPath.tsx
+++ b/src/components/ChapterPath.tsx
@@ -145,12 +145,12 @@ const ChapterPath: FC<ChapterPathProps> = ({ onSectionSelect }) => {
                     alignLeft ? 'justify-end mr-auto' : 'justify-start ml-auto'
                   )
                   const btnClass = clsx(
-                    'w-28 h-28 rounded-full border-4 flex items-center justify-center text-base font-medium bg-transparent',
+                    'w-18 h-18 rounded-full border-2 flex items-center justify-center text-xl font-bold bg-transparent',
                     sec.completed
                       ? 'border-emerald-600 text-emerald-600'
                       : sec.unlocked
                         ? 'border-emerald-600 text-emerald-600'
-                        : 'border-gray-300 text-gray-400 opacity-50 pointer-events-none'
+                        : 'border-gray-300 text-gray-400 opacity-50 pointer-events-none cursor-not-allowed'
                   )
                   return (
                     <motion.div

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,6 +5,7 @@ export default {
     extend: {
       spacing: {
         'safe': 'env(safe-area-inset-bottom)',
+        '18': '4.5rem',
       },
       screens: {
         'safe-area': 'screen and (display-mode: standalone)',


### PR DESCRIPTION
## Summary
- tweak `ChapterPath` button sizing and style
- add custom spacing `18` in Tailwind config

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68814419e6588324ac355c086a79b058