### PR TITLE
Simplify chapter path visuals

### DIFF
--- a/src/components/ChapterPath.tsx
+++ b/src/components/ChapterPath.tsx
@@ -1,10 +1,9 @@
-import { useEffect, useState, type FC, useRef, useLayoutEffect } from 'react'
+import { useEffect, useState, type FC } from 'react'
 import clsx from 'clsx'
 import { motion } from 'framer-motion'
 import { fetchChapters, fetchSections } from '../services/courseService'
 import { useAuth } from './SupabaseAuthProvider'
 import useUserProgress from '../hooks/useUserProgress'
-import ZigZagPath from './ui/ZigZagPath'
 import { getChapterTitle } from '../utils/courseTitles'
 
 interface ChapterPathProps {
@@ -37,19 +36,6 @@ const ChapterPath: FC<ChapterPathProps> = ({ onSectionSelect }) => {
   const [chapters, setChapters] = useState<ChapterData[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const containerRef = useRef<HTMLDivElement>(null)
-  const [width, setWidth] = useState(100)
-
-  useLayoutEffect(() => {
-    const update = () => {
-      if (containerRef.current) {
-        setWidth(containerRef.current.offsetWidth)
-      }
-    }
-    update()
-    window.addEventListener('resize', update)
-    return () => window.removeEventListener('resize', update)
-  }, [])
 
   useEffect(() => {
     const load = async () => {
@@ -95,86 +81,60 @@ const ChapterPath: FC<ChapterPathProps> = ({ onSectionSelect }) => {
     return <div className="p-6 text-red-600">{error}</div>
   }
 
-  const step = 136
-  const radius = 56
-  const offset = 10
-  const leftX = radius + offset
-  const rightX = width - radius - offset
-  const controlX = width / 2
-
-  const getPoint = (idx: number) => ({
-    x: idx % 2 === 0 ? leftX : rightX,
-    y: idx * step + radius
-  })
+  const circleSize = 96
+  const marginY = 48
+  const step = circleSize + marginY
 
   return (
     <div
       className="min-h-screen overflow-y-auto pb-safe px-4 pt-4 space-y-8 max-w-screen-sm mx-auto"
-      ref={containerRef}
     >
       {chapters.map(ch => {
-        const paths = ch.sections.slice(0, -1).map((_, idx) => {
-          const start = getPoint(idx)
-          const end = getPoint(idx + 1)
-          const midY = (start.y + end.y) / 2
-          return `M${start.x},${start.y} Q${controlX},${midY} ${end.x},${end.y}`
-        })
-        const svgHeight = Math.max(step * (ch.sections.length - 1) + radius * 2, 0)
+        const containerHeight = step * (ch.sections.length - 1) + circleSize
 
         return (
           <div key={ch.id} className="overflow-y-auto max-h-[calc(100vh-200px)]">
             <h2 className="text-lg font-semibold text-emerald-900 text-center mb-4">
               {`${ch.id} ${ch.title}`}
             </h2>
-            <div className="relative">
-              <svg
-                className="absolute inset-0 w-full h-full pointer-events-none"
-                viewBox={`0 0 ${width} ${svgHeight}`}
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                {paths.map((d, i) => (
-                  <ZigZagPath key={i} d={d} index={i} />
-                ))}
-              </svg>
-              <div className="flex flex-col items-center gap-y-6 relative w-full">
-                {ch.sections.map((sec, idx) => {
-                  const alignLeft = idx % 2 === 0
-                  const wrapper = clsx(
-                    'px-6 w-full flex',
-                    alignLeft ? 'justify-end mr-auto' : 'justify-start ml-auto'
-                  )
-                  const btnClass = clsx(
-                    'w-18 h-18 rounded-full border-2 flex items-center justify-center text-xl font-bold bg-transparent',
-                    sec.completed
+            <div className="relative" style={{ height: containerHeight }}>
+              {ch.sections.map((sec, idx) => {
+                const alignLeft = idx % 2 === 0
+                const wrapperClass = clsx(
+                  'absolute flex flex-col items-center',
+                  alignLeft ? 'left-4' : 'right-4'
+                )
+                const btnClass = clsx(
+                  'w-24 h-24 rounded-full border-2 flex items-center justify-center text-2xl font-bold bg-transparent',
+                  sec.completed
+                    ? 'border-emerald-600 text-emerald-600'
+                    : sec.unlocked
                       ? 'border-emerald-600 text-emerald-600'
-                      : sec.unlocked
-                        ? 'border-emerald-600 text-emerald-600'
-                        : 'border-gray-300 text-gray-400 opacity-50 pointer-events-none cursor-not-allowed'
-                  )
-                  return (
-                    <motion.div
-                      key={sec.id}
-                      className={clsx('flex flex-col items-center', wrapper)}
-                      variants={circleVariants}
-                      initial="hidden"
-                      animate="visible"
-                      custom={idx}
+                      : 'border-gray-300 text-gray-400 opacity-50 pointer-events-none cursor-not-allowed'
+                )
+                return (
+                  <motion.div
+                    key={sec.id}
+                    className={wrapperClass}
+                    style={{ top: idx * step }}
+                    variants={circleVariants}
+                    initial="hidden"
+                    animate="visible"
+                    custom={idx}
+                  >
+                    <button
+                      onClick={() => sec.unlocked && onSectionSelect(ch.id, sec.id)}
+                      className={btnClass}
                     >
-                      <button
-                        onClick={() => sec.unlocked && onSectionSelect(ch.id, sec.id)}
-                        className={btnClass}
-                      >
-                        {sec.index}
-                      </button>
-                      {sec.completed && (
-                        <span className="mt-1 text-[10px] text-emerald-600">+{sec.xp} XP</span>
-                      )}
-                    </motion.div>
-                  )
-                })}
+                      {sec.index}
+                    </button>
+                    {sec.completed && (
+                      <span className="mt-1 text-[10px] text-emerald-600">+{sec.xp} XP</span>
+                    )}
+                  </motion.div>
+                )
+              })}
               </div>
-            </div>
           </div>
         )
       })}

--- a/test/chapterpath.test.js
+++ b/test/chapterpath.test.js
@@ -68,9 +68,9 @@ test('ChapterPath renders layout correctly', async () => {
   assert.equal(buttons.length, 3);
 
   const paths = container.querySelectorAll('svg path');
-  assert.equal(paths.length, 2);
+  assert.equal(paths.length, 0);
 
-  const wrappers = container.querySelectorAll('div.px-6');
-  assert.ok(wrappers[0].className.includes('mr-auto'));
-  assert.ok(wrappers[1].className.includes('ml-auto'));
+  const wrappers = container.querySelectorAll('div.absolute');
+  assert.ok(wrappers[0].className.includes('left-4'));
+  assert.ok(wrappers[1].className.includes('right-4'));
 });


### PR DESCRIPTION
## Summary
- update `ChapterPath` component to remove zig-zag connectors
- alternate circle alignment using absolute positioning
- enlarge section circles and bold numbers
- adjust ChapterPath tests for new layout

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688156eaaf508324a1cd68fb4258671a